### PR TITLE
Update README.md with two features that should be implemented.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ Plugin for [OBS Studio](https://github.com/obsproject/obs-studio) to add [![Aitu
 
 # Translations
 Please read [Translations](TRANSLATIONS.md)
+
+
+# Upgrade Requests - Issues
+- The configuration should save between profiles.
+- Make other Stream outputs into "video encoder" stream possibilities so as to allow multiple streams for the one type of encoder rather than having to multiply the encoders out per stream.  This allows for only 2 encoders when there are 3 or more streams.  


### PR DESCRIPTION
I don't know how to get these through to the devs.  I was going to post an issue ticket but that feature is turn off on your repo?

Whatever.  I expect this pull request to be denied, full out.  Which is ok.

These two features would ROCK the multi-streamer world.  It'd bring Aitum into 2025 in a smashing way.  These would be a great upgrade:

- Allow a multi-stream advanced "Video Encoder" to select another "Output" that is hard set.  Meaning we can't select the video encoder to be another output that itself is selected to re-output.   This means that "main encoder" is supplemented with any "output" where the "video encoder" is not another output.  This allows a second output to be restreamed to a third location without having a third video encoder.  If the third location can't do the main stream, but can work with the second video encoder, there shouldn't have to be 3 encodes being performed.
- selecting between PROFILES deletes the multistream settings, and it's not restored when going back to the original profile.  I don't know if there is anything that can be done about this.  It may require some changes to how OBS handles plugins and the data provided to them.  eg.  Plugins would need access to which profile is selected and when a profile is changed.