### PR TITLE
Important crash: info is freed in callback, can't visit it.

### DIFF
--- a/file-updater.c
+++ b/file-updater.c
@@ -135,7 +135,7 @@ static void *single_file_thread(void *data)
 	download_data.version = 0;
 	download_data.buffer.da = info->file_data.da;
 	info->callback(info->param, &download_data);
-	info->file_data.da = download_data.buffer.da;
+	//info is freed in callback, can't visit it.
 	return NULL;
 }
 


### PR DESCRIPTION
Due to this problem, other modules will randomly crash, which is difficult to troubleshoot and has affected our normal use.
Please make sure to deal with it

### Description
After obs-studio loads aitum, since aitum modifies the released memory, it may cause the program to crash in any subsequent stack

### Probability of recurrence
1/50 ~ 1/20

### Impact System
- MacOS 15.5 (24F74) Will crash anywhere
- Windows (Not tested, performance unknown)

### Steps to reproduce
1. Start obs-studio
2. Wait for atium's obs_module_load method to be called
3. Wait for the main window to appear
4. Crashed  （Usually crashes within seconds after `info->file_data.da = download_data.buffer.da;`）， if not stop app and retry 1-3.


### Crash Analysis

1. `atium` -> `obs_module_load()`-> `update_info_create_single()`
2. `update_info_create_single()`-> `bzalloc()` info
3. `pthread_create()` -> `single_file_thread()`
4. `http_write` -> `da_push_back_array(info->file_data, ptr, total);`  (alloc and set value to `file_data`)
5. `info->callback(info->param, &download_data);` -> `update_info_destroy` ->  `da_free(info->file_data);` and `bfree(info);`
6. If other modules apply for this memory during this period
7. `info->file_data.da = download_data.buffer.da;` （**Modify memory that has been freed, or modify memory that has been allocated elsewhere**）

### Specific crash example
`da.array:0x600003ff4980` and The memory layout is as follows
![Snipaste_2025-07-08_09-55-14](https://github.com/user-attachments/assets/560adde0-a1be-464c-9705-13944880e458)

When the program crashes, check the assembly address as follows.
The address of x0 is `x0 = 0x0000600003ff4980`, which is exactly the same as the address of `da.array` in the figure above.
So the crash is caused by abnormal memory usage of da.array

![Snipaste_2025-07-08_09-55-46](https://github.com/user-attachments/assets/30a389b9-d665-49ed-bc72-771c554dbc12)

### Other Stacks
Other stack instances that have been reproduced due to this cause
![Snipaste_2025-07-07_13-49-57](https://github.com/user-attachments/assets/998c6b00-da1b-4210-b3da-21927119a9fe)
![Snipaste_2025-07-07_14-25-44](https://github.com/user-attachments/assets/e4a5678e-e2e5-4c0a-99e3-fab9116bc1de)
![Snipaste_2025-07-07_15-17-33](https://github.com/user-attachments/assets/cbd5af56-ef65-417e-b924-70eeaae78141)

and  other ....
