### PR TITLE
pass explicit long values to curl_easy_setopt

### DIFF
--- a/file-updater.c
+++ b/file-updater.c
@@ -83,8 +83,8 @@ static bool do_http_request(struct update_info *info, const char *url, long *res
 	curl_easy_setopt(info->curl, CURLOPT_ERRORBUFFER, info->error);
 	curl_easy_setopt(info->curl, CURLOPT_WRITEFUNCTION, http_write);
 	curl_easy_setopt(info->curl, CURLOPT_WRITEDATA, info);
-	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
-	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
+	curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, 1L);
+	curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1L);
 	curl_easy_setopt(info->curl, CURLOPT_ACCEPT_ENCODING, "");
 	curl_obs_set_revoke_setting(info->curl);
 


### PR DESCRIPTION
On NixOS, this plugin fails to compile currently due to `-Werror=attribute-warning`:

```
> /build/source/file-updater.c:86:9: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
>    86 |         curl_easy_setopt(info->curl, CURLOPT_FAILONERROR, true);
>       | 
```

```
/build/source/file-updater.c:87:9: error: call to '_curl_easy_setopt_err_long' declared with attribute warning: curl_easy_setopt expects a long argument [-Werror=attribute-warning]
   87 |         curl_easy_setopt(info->curl, CURLOPT_NOSIGNAL, 1);
      |         ^~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

This patch simply fixes the curl opts types to long values.