### PR TITLE
macOS Keychain storage for stream keys

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,16 @@ target_sources(${PROJECT_NAME} PRIVATE
 	output-dialog.hpp
 	stream-key-input.hpp
     multistream.hpp
-	file-updater.h)
+	file-updater.h
+	keychain-helper.hpp)
+
+# macOS Keychain support for secure stream key storage
+if(APPLE)
+  target_sources(${PROJECT_NAME} PRIVATE keychain-helper.mm)
+  target_link_libraries(${PROJECT_NAME} PRIVATE "-framework Security" "-framework CoreFoundation")
+else()
+  target_sources(${PROJECT_NAME} PRIVATE keychain-helper-stub.cpp)
+endif()
 
 if(BUILD_OUT_OF_TREE)
 	set_target_properties_plugin(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${_name})

--- a/config-dialog.cpp
+++ b/config-dialog.cpp
@@ -32,6 +32,7 @@
 #include <util/config-file.h>
 #include "output-dialog.hpp"
 #include "config-utils.hpp"
+#include "keychain-helper.hpp"
 
 #ifndef _WIN32
 #include <dlfcn.h>
@@ -923,6 +924,14 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 	removeButton->setProperty("themeID", QVariant(QString::fromUtf8("removeIconSmall")));
 	removeButton->setProperty("class", "icon-minus");
 	connect(removeButton, &QPushButton::clicked, [this, outputsLayout, serverGroup, settings, outputs] {
+#if KEYCHAIN_AVAILABLE
+		// Clean up keychain entry when an output is removed
+		auto rm_name = obs_data_get_string(settings, "name");
+		if (rm_name && rm_name[0] != '\0') {
+			auto svc = keychain::make_service_name(rm_name);
+			keychain::delete_secret(svc, rm_name);
+		}
+#endif
 		outputsLayout->removeWidget(serverGroup);
 		RemoveWidget(serverGroup);
 		auto count = obs_data_array_count(outputs);
@@ -952,6 +961,10 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 			&otherNames);
 		otherNames.removeDuplicates();
 		otherNames.removeOne(QString::fromUtf8(obs_data_get_string(settings, "name")));
+#if KEYCHAIN_AVAILABLE
+		// Capture the old name before editing, so we can clean up keychain if renamed
+		std::string old_output_name = obs_data_get_string(settings, "name");
+#endif
 		auto outputDialog = new OutputDialog(this, obs_data_get_string(settings, "name"),
 						     obs_data_get_string(settings, "stream_server"),
 						     obs_data_get_string(settings, "stream_key"), otherNames);
@@ -965,6 +978,14 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 
 			if (outputs == vertical_outputs)
 				obs_data_set_bool(settings, "enabled", true);
+#if KEYCHAIN_AVAILABLE
+			// If output was renamed, delete the old keychain entry
+			std::string new_name = outputDialog->outputName.toUtf8().constData();
+			if (!old_output_name.empty() && old_output_name != new_name) {
+				auto old_svc = keychain::make_service_name(old_output_name);
+				keychain::delete_secret(old_svc, old_output_name);
+			}
+#endif
 			// Set the info from the output dialog
 			obs_data_set_string(settings, "name", outputDialog->outputName.toUtf8().constData());
 			obs_data_set_string(settings, "stream_server", outputDialog->outputServer.toUtf8().constData());

--- a/config-dialog.cpp
+++ b/config-dialog.cpp
@@ -111,6 +111,12 @@ OBSBasicSettings::OBSBasicSettings(QMainWindow *parent) : QDialog(parent)
 	infoLabel->setWordWrap(true);
 	infoLayout->addWidget(infoLabel, 1);
 
+#ifdef __APPLE__
+	keychainCheckbox = new QCheckBox(QString::fromUtf8(obs_module_text("KeychainSettingLabel")));
+	keychainCheckbox->setToolTip(QString::fromUtf8(obs_module_text("KeychainSettingTooltip")));
+	infoLayout->addWidget(keychainCheckbox);
+#endif
+
 	auto buttonGroupBox = new QWidget();
 	auto buttonLayout = new QHBoxLayout;
 	buttonLayout->setSpacing(8);
@@ -924,14 +930,14 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 	removeButton->setProperty("themeID", QVariant(QString::fromUtf8("removeIconSmall")));
 	removeButton->setProperty("class", "icon-minus");
 	connect(removeButton, &QPushButton::clicked, [this, outputsLayout, serverGroup, settings, outputs] {
-#if KEYCHAIN_AVAILABLE
 		// Clean up keychain entry when an output is removed
 		auto rm_name = obs_data_get_string(settings, "name");
 		if (rm_name && rm_name[0] != '\0') {
-			auto svc = keychain::make_service_name(rm_name);
+			bool is_vertical = (outputs == vertical_outputs);
+			auto svc = is_vertical ? keychain::make_vertical_service_name(rm_name)
+					       : keychain::make_service_name(rm_name);
 			keychain::delete_secret(svc, rm_name);
 		}
-#endif
 		outputsLayout->removeWidget(serverGroup);
 		RemoveWidget(serverGroup);
 		auto count = obs_data_array_count(outputs);
@@ -961,13 +967,14 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 			&otherNames);
 		otherNames.removeDuplicates();
 		otherNames.removeOne(QString::fromUtf8(obs_data_get_string(settings, "name")));
-#if KEYCHAIN_AVAILABLE
 		// Capture the old name before editing, so we can clean up keychain if renamed
 		std::string old_output_name = obs_data_get_string(settings, "name");
-#endif
+		auto kc_svc = obs_data_get_string(settings, "keychain_service");
+		bool has_keychain = kc_svc && kc_svc[0] != '\0';
 		auto outputDialog = new OutputDialog(this, obs_data_get_string(settings, "name"),
 						     obs_data_get_string(settings, "stream_server"),
-						     obs_data_get_string(settings, "stream_key"), otherNames);
+						     obs_data_get_string(settings, "stream_key"), otherNames,
+						     has_keychain);
 
 		outputDialog->setWindowModality(Qt::WindowModal);
 		outputDialog->setModal(true);
@@ -978,14 +985,14 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 
 			if (outputs == vertical_outputs)
 				obs_data_set_bool(settings, "enabled", true);
-#if KEYCHAIN_AVAILABLE
 			// If output was renamed, delete the old keychain entry
 			std::string new_name = outputDialog->outputName.toUtf8().constData();
 			if (!old_output_name.empty() && old_output_name != new_name) {
-				auto old_svc = keychain::make_service_name(old_output_name);
+				bool is_vertical = (outputs == vertical_outputs);
+				auto old_svc = is_vertical ? keychain::make_vertical_service_name(old_output_name)
+							   : keychain::make_service_name(old_output_name);
 				keychain::delete_secret(old_svc, old_output_name);
 			}
-#endif
 			// Set the info from the output dialog
 			obs_data_set_string(settings, "name", outputDialog->outputName.toUtf8().constData());
 			obs_data_set_string(settings, "stream_server", outputDialog->outputServer.toUtf8().constData());
@@ -1034,6 +1041,9 @@ void OBSBasicSettings::LoadVerticalSettings(bool load)
 			obs_data_array_release(vertical_outputs);
 		vertical_outputs = (obs_data_array_t *)calldata_ptr(&cd, "outputs");
 		calldata_free(&cd);
+
+		// Stream keys are NOT hydrated — they stay in Keychain and are
+		// retrieved on-demand at stream start time.
 	}
 	obs_data_array_enum(
 		vertical_outputs,
@@ -1048,12 +1058,44 @@ void OBSBasicSettings::SaveVerticalSettings()
 {
 	if (!vertical_outputs)
 		return;
+
+	bool useKeychain = IsKeychainEnabled();
+
+	// When Keychain is enabled, store vertical output stream keys in Keychain
+	// and strip from data before sending to the vertical plugin.
+	auto sanitized = obs_data_array_create();
+	auto count = obs_data_array_count(vertical_outputs);
+	for (size_t i = 0; i < count; i++) {
+		auto output = obs_data_array_item(vertical_outputs, i);
+		if (!output)
+			continue;
+		auto json = obs_data_get_json(output);
+		auto copy = obs_data_create_from_json(json);
+
+		if (useKeychain) {
+			auto name = obs_data_get_string(copy, "name");
+			auto key = obs_data_get_string(copy, "stream_key");
+			if (name && name[0] != '\0' && key && key[0] != '\0') {
+				auto svc = keychain::make_vertical_service_name(name);
+				if (keychain::store_secret(svc, name, key)) {
+					obs_data_set_string(copy, "keychain_service", svc.c_str());
+					obs_data_erase(copy, "stream_key");
+				}
+			}
+		}
+
+		obs_data_array_push_back(sanitized, copy);
+		obs_data_release(copy);
+		obs_data_release(output);
+	}
+
 	auto ph = obs_get_proc_handler();
 	struct calldata cd;
 	calldata_init(&cd);
-	calldata_set_ptr(&cd, "outputs", vertical_outputs);
+	calldata_set_ptr(&cd, "outputs", sanitized);
 	proc_handler_call(ph, "aitum_vertical_set_stream_settings", &cd);
 	calldata_free(&cd);
+	obs_data_array_release(sanitized);
 }
 
 void OBSBasicSettings::LoadSettings(obs_data_t *settings)
@@ -1497,4 +1539,23 @@ void OBSBasicSettings::SetNewerVersion(QString newer_version_available)
 		return;
 	newVersion->setText(QString::fromUtf8(obs_module_text("NewVersion")).arg(newer_version_available));
 	newVersion->setVisible(true);
+}
+
+void OBSBasicSettings::SetKeychainEnabled(bool enabled)
+{
+#ifdef __APPLE__
+	if (keychainCheckbox)
+		keychainCheckbox->setChecked(enabled);
+#else
+	UNUSED_PARAMETER(enabled);
+#endif
+}
+
+bool OBSBasicSettings::IsKeychainEnabled() const
+{
+#ifdef __APPLE__
+	return keychainCheckbox && keychainCheckbox->isChecked();
+#else
+	return false;
+#endif
 }

--- a/config-dialog.hpp
+++ b/config-dialog.hpp
@@ -63,6 +63,8 @@ private:
 	QToolButton *generalHelpButton;
 	QToolButton *generalSupportAitumButton;
 
+	QCheckBox *keychainCheckbox = nullptr;
+
 private slots:
 	void SetGeneralIcon(const QIcon &icon);
 	void SetAppearanceIcon(const QIcon &icon);
@@ -83,6 +85,8 @@ public:
 	void SaveVerticalSettings();
 	void LoadOutputStats(std::vector<video_t *> *oldVideos);
 	void SetNewerVersion(QString newer_version_available);
+	void SetKeychainEnabled(bool enabled);
+	bool IsKeychainEnabled() const;
 
 public slots:
 };

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -138,3 +138,8 @@ CustomServer="Server"
 CustomServerInfo="Please enter the server URL provided by the site."
 CustomStreamKey="Stream Key"
 CustomStreamKeyInfo="Please enter your stream key, provide by the site."
+
+# Keychain (macOS)
+KeychainSettingLabel="Store stream keys securely in macOS Keychain"
+KeychainSettingTooltip="When enabled, stream keys are stored in the macOS Keychain instead of the plugin config file. Keys are never displayed once stored."
+StreamKeySavedInKeychain="Stream key saved in Keychain (leave blank to keep)"

--- a/keychain-helper-stub.cpp
+++ b/keychain-helper-stub.cpp
@@ -12,6 +12,11 @@ std::string make_service_name(const std::string &output_name)
 	return std::string(KEYCHAIN_SERVICE_PREFIX) + output_name;
 }
 
+std::string make_vertical_service_name(const std::string &output_name)
+{
+	return std::string(KEYCHAIN_SERVICE_PREFIX) + "vertical." + output_name;
+}
+
 bool store_secret(const std::string &, const std::string &, const std::string &)
 {
 	return false;

--- a/keychain-helper-stub.cpp
+++ b/keychain-helper-stub.cpp
@@ -1,0 +1,32 @@
+#include "keychain-helper.hpp"
+
+#ifndef __APPLE__
+
+// Stub implementations for non-macOS platforms.
+// These are no-ops; stream keys fall back to plaintext config storage.
+
+namespace keychain {
+
+std::string make_service_name(const std::string &output_name)
+{
+	return std::string(KEYCHAIN_SERVICE_PREFIX) + output_name;
+}
+
+bool store_secret(const std::string &, const std::string &, const std::string &)
+{
+	return false;
+}
+
+std::string retrieve_secret(const std::string &, const std::string &)
+{
+	return "";
+}
+
+bool delete_secret(const std::string &, const std::string &)
+{
+	return false;
+}
+
+} // namespace keychain
+
+#endif // !__APPLE__

--- a/keychain-helper.hpp
+++ b/keychain-helper.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#ifdef __APPLE__
+#define KEYCHAIN_AVAILABLE 1
+#else
+#define KEYCHAIN_AVAILABLE 0
+#endif
+
+// Service name prefix for keychain entries
+#define KEYCHAIN_SERVICE_PREFIX "com.aitum.multistream."
+
+namespace keychain {
+
+/**
+ * Store a secret (stream key) in the macOS Keychain.
+ * On non-macOS platforms, this is a no-op that returns false.
+ *
+ * @param service_name  The keychain service name (e.g. "com.aitum.multistream.Twitch")
+ * @param account       The account name (e.g. the output name)
+ * @param secret        The secret to store (e.g. the stream key)
+ * @return true on success, false on failure
+ */
+bool store_secret(const std::string &service_name, const std::string &account, const std::string &secret);
+
+/**
+ * Retrieve a secret (stream key) from the macOS Keychain.
+ * On non-macOS platforms, this is a no-op that returns an empty string.
+ *
+ * @param service_name  The keychain service name
+ * @param account       The account name
+ * @return The secret string, or empty string on failure
+ */
+std::string retrieve_secret(const std::string &service_name, const std::string &account);
+
+/**
+ * Delete a secret from the macOS Keychain.
+ * On non-macOS platforms, this is a no-op that returns false.
+ *
+ * @param service_name  The keychain service name
+ * @param account       The account name
+ * @return true on success, false on failure/not found
+ */
+bool delete_secret(const std::string &service_name, const std::string &account);
+
+/**
+ * Build a keychain service name from an output name.
+ * Returns "com.aitum.multistream.<output_name>"
+ */
+std::string make_service_name(const std::string &output_name);
+
+} // namespace keychain

--- a/keychain-helper.hpp
+++ b/keychain-helper.hpp
@@ -2,12 +2,6 @@
 
 #include <string>
 
-#ifdef __APPLE__
-#define KEYCHAIN_AVAILABLE 1
-#else
-#define KEYCHAIN_AVAILABLE 0
-#endif
-
 // Service name prefix for keychain entries
 #define KEYCHAIN_SERVICE_PREFIX "com.aitum.multistream."
 
@@ -49,5 +43,11 @@ bool delete_secret(const std::string &service_name, const std::string &account);
  * Returns "com.aitum.multistream.<output_name>"
  */
 std::string make_service_name(const std::string &output_name);
+
+/**
+ * Build a keychain service name for a vertical canvas output.
+ * Returns "com.aitum.multistream.vertical.<output_name>"
+ */
+std::string make_vertical_service_name(const std::string &output_name);
 
 } // namespace keychain

--- a/keychain-helper.mm
+++ b/keychain-helper.mm
@@ -13,6 +13,11 @@ std::string make_service_name(const std::string &output_name)
 	return std::string(KEYCHAIN_SERVICE_PREFIX) + output_name;
 }
 
+std::string make_vertical_service_name(const std::string &output_name)
+{
+	return std::string(KEYCHAIN_SERVICE_PREFIX) + "vertical." + output_name;
+}
+
 bool store_secret(const std::string &service_name, const std::string &account, const std::string &secret)
 {
 	if (service_name.empty() || secret.empty())
@@ -73,7 +78,7 @@ bool store_secret(const std::string &service_name, const std::string &account, c
 		return false;
 	}
 
-	blog(LOG_INFO, "[Aitum Multistream] Keychain: stored secret for service '%s'", service_name.c_str());
+	blog(LOG_DEBUG, "[Aitum Multistream] Keychain: stored secret for service '%s'", service_name.c_str());
 	return true;
 }
 
@@ -120,7 +125,7 @@ std::string retrieve_secret(const std::string &service_name, const std::string &
 	std::string secret((const char *)CFDataGetBytePtr(data), (size_t)CFDataGetLength(data));
 	CFRelease(result);
 
-	blog(LOG_INFO, "[Aitum Multistream] Keychain: retrieved secret for service '%s'", service_name.c_str());
+	blog(LOG_DEBUG, "[Aitum Multistream] Keychain: retrieved secret for service '%s'", service_name.c_str());
 	return secret;
 }
 
@@ -158,7 +163,7 @@ bool delete_secret(const std::string &service_name, const std::string &account)
 		return false;
 	}
 
-	blog(LOG_INFO, "[Aitum Multistream] Keychain: deleted secret for service '%s'", service_name.c_str());
+	blog(LOG_DEBUG, "[Aitum Multistream] Keychain: deleted secret for service '%s'", service_name.c_str());
 	return true;
 }
 

--- a/keychain-helper.mm
+++ b/keychain-helper.mm
@@ -1,0 +1,167 @@
+#include "keychain-helper.hpp"
+
+#ifdef __APPLE__
+
+#include <Security/Security.h>
+#include <CoreFoundation/CoreFoundation.h>
+#include <obs.h>
+
+namespace keychain {
+
+std::string make_service_name(const std::string &output_name)
+{
+	return std::string(KEYCHAIN_SERVICE_PREFIX) + output_name;
+}
+
+bool store_secret(const std::string &service_name, const std::string &account, const std::string &secret)
+{
+	if (service_name.empty() || secret.empty())
+		return false;
+
+	CFStringRef cf_service =
+		CFStringCreateWithCString(kCFAllocatorDefault, service_name.c_str(), kCFStringEncodingUTF8);
+	CFStringRef cf_account = CFStringCreateWithCString(kCFAllocatorDefault, account.c_str(), kCFStringEncodingUTF8);
+	CFDataRef cf_secret = CFDataCreate(kCFAllocatorDefault, (const UInt8 *)secret.c_str(), (CFIndex)secret.length());
+
+	if (!cf_service || !cf_account || !cf_secret) {
+		if (cf_service)
+			CFRelease(cf_service);
+		if (cf_account)
+			CFRelease(cf_account);
+		if (cf_secret)
+			CFRelease(cf_secret);
+		return false;
+	}
+
+	// First try to update an existing item
+	const void *query_keys[] = {kSecClass, kSecAttrService, kSecAttrAccount};
+	const void *query_values[] = {kSecClassGenericPassword, cf_service, cf_account};
+	CFDictionaryRef query =
+		CFDictionaryCreate(kCFAllocatorDefault, query_keys, query_values, 3, &kCFTypeDictionaryKeyCallBacks,
+				   &kCFTypeDictionaryValueCallBacks);
+
+	const void *update_keys[] = {kSecValueData};
+	const void *update_values[] = {cf_secret};
+	CFDictionaryRef update = CFDictionaryCreate(kCFAllocatorDefault, update_keys, update_values, 1,
+						    &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+	OSStatus status = SecItemUpdate(query, update);
+	CFRelease(update);
+
+	if (status == errSecItemNotFound) {
+		// Item doesn't exist yet, add it
+		CFRelease(query);
+		const void *add_keys[] = {kSecClass, kSecAttrService, kSecAttrAccount, kSecValueData};
+		const void *add_values[] = {kSecClassGenericPassword, cf_service, cf_account, cf_secret};
+		CFDictionaryRef add_dict =
+			CFDictionaryCreate(kCFAllocatorDefault, add_keys, add_values, 4, &kCFTypeDictionaryKeyCallBacks,
+					   &kCFTypeDictionaryValueCallBacks);
+
+		status = SecItemAdd(add_dict, nullptr);
+		CFRelease(add_dict);
+	} else {
+		CFRelease(query);
+	}
+
+	CFRelease(cf_service);
+	CFRelease(cf_account);
+	CFRelease(cf_secret);
+
+	if (status != errSecSuccess) {
+		blog(LOG_WARNING, "[Aitum Multistream] Keychain store failed for service '%s': OSStatus %d",
+		     service_name.c_str(), (int)status);
+		return false;
+	}
+
+	blog(LOG_INFO, "[Aitum Multistream] Keychain: stored secret for service '%s'", service_name.c_str());
+	return true;
+}
+
+std::string retrieve_secret(const std::string &service_name, const std::string &account)
+{
+	if (service_name.empty())
+		return "";
+
+	CFStringRef cf_service =
+		CFStringCreateWithCString(kCFAllocatorDefault, service_name.c_str(), kCFStringEncodingUTF8);
+	CFStringRef cf_account = CFStringCreateWithCString(kCFAllocatorDefault, account.c_str(), kCFStringEncodingUTF8);
+
+	if (!cf_service || !cf_account) {
+		if (cf_service)
+			CFRelease(cf_service);
+		if (cf_account)
+			CFRelease(cf_account);
+		return "";
+	}
+
+	const void *query_keys[] = {kSecClass, kSecAttrService, kSecAttrAccount, kSecReturnData, kSecMatchLimit};
+	const void *query_values[] = {kSecClassGenericPassword, cf_service, cf_account, kCFBooleanTrue, kSecMatchLimitOne};
+	CFDictionaryRef query =
+		CFDictionaryCreate(kCFAllocatorDefault, query_keys, query_values, 5, &kCFTypeDictionaryKeyCallBacks,
+				   &kCFTypeDictionaryValueCallBacks);
+
+	CFTypeRef result = nullptr;
+	OSStatus status = SecItemCopyMatching(query, &result);
+	CFRelease(query);
+	CFRelease(cf_service);
+	CFRelease(cf_account);
+
+	if (status != errSecSuccess || !result) {
+		if (status != errSecItemNotFound) {
+			blog(LOG_WARNING, "[Aitum Multistream] Keychain retrieve failed for service '%s': OSStatus %d",
+			     service_name.c_str(), (int)status);
+		}
+		if (result)
+			CFRelease(result);
+		return "";
+	}
+
+	CFDataRef data = (CFDataRef)result;
+	std::string secret((const char *)CFDataGetBytePtr(data), (size_t)CFDataGetLength(data));
+	CFRelease(result);
+
+	blog(LOG_INFO, "[Aitum Multistream] Keychain: retrieved secret for service '%s'", service_name.c_str());
+	return secret;
+}
+
+bool delete_secret(const std::string &service_name, const std::string &account)
+{
+	if (service_name.empty())
+		return false;
+
+	CFStringRef cf_service =
+		CFStringCreateWithCString(kCFAllocatorDefault, service_name.c_str(), kCFStringEncodingUTF8);
+	CFStringRef cf_account = CFStringCreateWithCString(kCFAllocatorDefault, account.c_str(), kCFStringEncodingUTF8);
+
+	if (!cf_service || !cf_account) {
+		if (cf_service)
+			CFRelease(cf_service);
+		if (cf_account)
+			CFRelease(cf_account);
+		return false;
+	}
+
+	const void *query_keys[] = {kSecClass, kSecAttrService, kSecAttrAccount};
+	const void *query_values[] = {kSecClassGenericPassword, cf_service, cf_account};
+	CFDictionaryRef query =
+		CFDictionaryCreate(kCFAllocatorDefault, query_keys, query_values, 3, &kCFTypeDictionaryKeyCallBacks,
+				   &kCFTypeDictionaryValueCallBacks);
+
+	OSStatus status = SecItemDelete(query);
+	CFRelease(query);
+	CFRelease(cf_service);
+	CFRelease(cf_account);
+
+	if (status != errSecSuccess && status != errSecItemNotFound) {
+		blog(LOG_WARNING, "[Aitum Multistream] Keychain delete failed for service '%s': OSStatus %d",
+		     service_name.c_str(), (int)status);
+		return false;
+	}
+
+	blog(LOG_INFO, "[Aitum Multistream] Keychain: deleted secret for service '%s'", service_name.c_str());
+	return true;
+}
+
+} // namespace keychain
+
+#endif // __APPLE__

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -1,4 +1,5 @@
 #include "config-utils.hpp"
+#include "keychain-helper.hpp"
 #include "multistream.hpp"
 #include "obs-module.h"
 #include "version.h"
@@ -798,6 +799,34 @@ void MultistreamDock::SaveSettings()
 	bfree(profile);
 	if (current_config)
 		obs_data_apply(pd, current_config);
+
+#if KEYCHAIN_AVAILABLE
+	// Move stream keys from the on-disk data into macOS Keychain.
+	// The in-memory current_config keeps stream_key for runtime use.
+	{
+		auto outputs_arr = obs_data_get_array(pd, "outputs");
+		if (outputs_arr) {
+			auto count = obs_data_array_count(outputs_arr);
+			for (size_t i = 0; i < count; i++) {
+				auto output = obs_data_array_item(outputs_arr, i);
+				if (!output)
+					continue;
+				auto name = obs_data_get_string(output, "name");
+				auto key = obs_data_get_string(output, "stream_key");
+				if (name && name[0] != '\0' && key && key[0] != '\0') {
+					auto svc = keychain::make_service_name(name);
+					if (keychain::store_secret(svc, name, key)) {
+						obs_data_set_string(output, "keychain_service", svc.c_str());
+						obs_data_unset_user_value(output, "stream_key");
+					}
+				}
+				obs_data_release(output);
+			}
+			obs_data_array_release(outputs_arr);
+		}
+	}
+#endif
+
 	obs_data_release(pd);
 
 	if (obs_data_save_json_safe(config, path, "tmp", "bak")) {

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -556,6 +556,33 @@ void MultistreamDock::LoadSettingsFile()
 	}
 	bfree(profile);
 	current_config = pd;
+
+#if KEYCHAIN_AVAILABLE
+	// Hydrate stream keys from Keychain into in-memory config.
+	// The on-disk config stores keychain_service references instead of stream_key.
+	{
+		auto outputs_arr = obs_data_get_array(current_config, "outputs");
+		if (outputs_arr) {
+			auto count = obs_data_array_count(outputs_arr);
+			for (size_t i = 0; i < count; i++) {
+				auto output = obs_data_array_item(outputs_arr, i);
+				if (!output)
+					continue;
+				auto kc_svc = obs_data_get_string(output, "keychain_service");
+				auto oname = obs_data_get_string(output, "name");
+				if (kc_svc && kc_svc[0] != '\0' && oname && oname[0] != '\0') {
+					auto secret = keychain::retrieve_secret(kc_svc, oname);
+					if (!secret.empty()) {
+						obs_data_set_string(output, "stream_key", secret.c_str());
+					}
+				}
+				obs_data_release(output);
+			}
+			obs_data_array_release(outputs_arr);
+		}
+	}
+#endif
+
 	LoadSettings();
 }
 
@@ -988,6 +1015,20 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 		if (key && strlen(key))
 			obs_data_set_string(settings, "stream_key", key);
 	}
+#if KEYCHAIN_AVAILABLE
+	// Fallback: if stream_key is still empty, try retrieving from Keychain
+	std::string keychain_key_storage;
+	if (!key || !strlen(key)) {
+		auto kc_svc = obs_data_get_string(settings, "keychain_service");
+		if (kc_svc && kc_svc[0] != '\0') {
+			keychain_key_storage = keychain::retrieve_secret(kc_svc, name);
+			if (!keychain_key_storage.empty()) {
+				key = keychain_key_storage.c_str();
+				obs_data_set_string(settings, "stream_key", key);
+			}
+		}
+	}
+#endif
 	if (whip) {
 		obs_data_set_string(s, "bearer_token", key);
 	} else {

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -324,9 +324,11 @@ MultistreamDock::MultistreamDock(QWidget *parent) : QFrame(parent)
 		configDialog->LoadVerticalSettings(true);
 		configDialog->LoadOutputStats(&oldVideo);
 		configDialog->SetNewerVersion(newer_version_available);
+		configDialog->SetKeychainEnabled(keychainEnabled);
 		configDialog->setResult(QDialog::Rejected);
 		if (configDialog->exec() == QDialog::Accepted) {
 			if (current_config) {
+				keychainEnabled = configDialog->IsKeychainEnabled();
 				obs_data_apply(current_config, settings);
 				obs_data_release(settings);
 				SaveSettings();
@@ -528,6 +530,7 @@ void MultistreamDock::LoadSettingsFile()
 		blog(LOG_INFO, "[Aitum Multistream] Loaded configuration file");
 	}
 	partnerBlockTime = obs_data_get_int(config, "partner_block");
+	keychainEnabled = obs_data_get_bool(config, "keychain_enabled");
 
 	auto profiles = obs_data_get_array(config, "profiles");
 	auto pc = obs_data_array_count(profiles);
@@ -557,31 +560,10 @@ void MultistreamDock::LoadSettingsFile()
 	bfree(profile);
 	current_config = pd;
 
-#if KEYCHAIN_AVAILABLE
-	// Hydrate stream keys from Keychain into in-memory config.
-	// The on-disk config stores keychain_service references instead of stream_key.
-	{
-		auto outputs_arr = obs_data_get_array(current_config, "outputs");
-		if (outputs_arr) {
-			auto count = obs_data_array_count(outputs_arr);
-			for (size_t i = 0; i < count; i++) {
-				auto output = obs_data_array_item(outputs_arr, i);
-				if (!output)
-					continue;
-				auto kc_svc = obs_data_get_string(output, "keychain_service");
-				auto oname = obs_data_get_string(output, "name");
-				if (kc_svc && kc_svc[0] != '\0' && oname && oname[0] != '\0') {
-					auto secret = keychain::retrieve_secret(kc_svc, oname);
-					if (!secret.empty()) {
-						obs_data_set_string(output, "stream_key", secret.c_str());
-					}
-				}
-				obs_data_release(output);
-			}
-			obs_data_array_release(outputs_arr);
-		}
-	}
-#endif
+	// Stream keys are NOT hydrated into in-memory config.
+	// They stay in Keychain and are retrieved on-demand at stream start time
+	// (see StartOutput fallback). This prevents keys from leaking into the
+	// edit UI or being held in memory unnecessarily.
 
 	LoadSettings();
 }
@@ -795,6 +777,7 @@ void MultistreamDock::SaveSettings()
 		blog(LOG_WARNING, "[Aitum Multistream] New configuration file");
 	}
 	obs_data_set_int(config, "partner_block", partnerBlockTime);
+	obs_data_set_bool(config, "keychain_enabled", keychainEnabled);
 	auto profiles = obs_data_get_array(config, "profiles");
 	if (!profiles) {
 		profiles = obs_data_array_create();
@@ -827,10 +810,9 @@ void MultistreamDock::SaveSettings()
 	if (current_config)
 		obs_data_apply(pd, current_config);
 
-#if KEYCHAIN_AVAILABLE
-	// Move stream keys from the on-disk data into macOS Keychain.
-	// The in-memory current_config keeps stream_key for runtime use.
-	{
+	// When Keychain storage is enabled, move stream keys from the on-disk
+	// data into macOS Keychain so they don't sit in plaintext config.
+	if (keychainEnabled) {
 		auto outputs_arr = obs_data_get_array(pd, "outputs");
 		if (outputs_arr) {
 			auto count = obs_data_array_count(outputs_arr);
@@ -844,7 +826,7 @@ void MultistreamDock::SaveSettings()
 					auto svc = keychain::make_service_name(name);
 					if (keychain::store_secret(svc, name, key)) {
 						obs_data_set_string(output, "keychain_service", svc.c_str());
-						obs_data_unset_user_value(output, "stream_key");
+						obs_data_erase(output, "stream_key");
 					}
 				}
 				obs_data_release(output);
@@ -852,7 +834,6 @@ void MultistreamDock::SaveSettings()
 			obs_data_array_release(outputs_arr);
 		}
 	}
-#endif
 
 	obs_data_release(pd);
 
@@ -1015,7 +996,6 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 		if (key && strlen(key))
 			obs_data_set_string(settings, "stream_key", key);
 	}
-#if KEYCHAIN_AVAILABLE
 	// Fallback: if stream_key is still empty, try retrieving from Keychain
 	std::string keychain_key_storage;
 	if (!key || !strlen(key)) {
@@ -1028,7 +1008,6 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 			}
 		}
 	}
-#endif
 	if (whip) {
 		obs_data_set_string(s, "bearer_token", key);
 	} else {
@@ -1234,6 +1213,10 @@ void MultistreamDock::LoadVerticalOutputs(bool firstLoad)
 	vertical_outputs = (obs_data_array_t *)calldata_ptr(&cd, "outputs");
 
 	calldata_free(&cd);
+
+	// Stream keys are NOT hydrated — they stay in Keychain and are
+	// retrieved on-demand at stream start time.
+
 	int idx = 0;
 	while (auto item = verticalCanvasOutputLayout->itemAt(idx)) {
 		auto streamGroup = item->widget();

--- a/multistream.hpp
+++ b/multistream.hpp
@@ -39,6 +39,7 @@ private:
 	std::vector<std::tuple<std::string, obs_output_t *, QPushButton *>> outputs;
 	obs_data_array_t *vertical_outputs = nullptr;
 	bool exiting = false;
+	bool keychainEnabled = false;
 
 	void LoadSettingsFile();
 	void LoadSettings();

--- a/output-dialog.cpp
+++ b/output-dialog.cpp
@@ -38,7 +38,7 @@ void OutputDialog::validateOutputs(QPushButton *confirmButton)
 		confirmButton->setEnabled(false);
 	} else if (outputServer.isEmpty()) {
 		confirmButton->setEnabled(false);
-	} else if (outputKey.isEmpty()) {
+	} else if (outputKey.isEmpty() && !keychainStored) {
 		confirmButton->setEnabled(false);
 	} else {
 		confirmButton->setEnabled(true);
@@ -175,7 +175,11 @@ QLineEdit *OutputDialog::generateOutputKeyField(QPushButton *confirmButton, bool
 	auto field = new StreamKeyInput;
 	field->setStyleSheet("padding: 4px 8px;");
 
-	if (edit) { // edit mode, set field value from output value
+	if (edit && keychainStored) {
+		// Key is stored in Keychain — show placeholder, don't expose the key
+		field->setPlaceholderText(QString::fromUtf8(obs_module_text("StreamKeySavedInKeychain")));
+		field->setReadOnly(true);
+	} else if (edit) {
 		field->setText(outputKey);
 	}
 
@@ -183,7 +187,10 @@ QLineEdit *OutputDialog::generateOutputKeyField(QPushButton *confirmButton, bool
 	field->setEchoMode(StreamKeyInput::EchoMode::Password);
 
 	// On focus, show field
-	connect(field, &StreamKeyInput::focusGained, [this, field] { field->setEchoMode(StreamKeyInput::EchoMode::Normal); });
+	connect(field, &StreamKeyInput::focusGained, [this, field] {
+		if (!keychainStored)
+			field->setEchoMode(StreamKeyInput::EchoMode::Normal);
+	});
 
 	// On blur, hide field
 	connect(field, &StreamKeyInput::focusLost, [this, field] { field->setEchoMode(StreamKeyInput::EchoMode::Password); });
@@ -324,9 +331,11 @@ OutputDialog::OutputDialog(QDialog *parent, QStringList _otherNames) : QDialog(p
 }
 
 // Edit mode
-OutputDialog::OutputDialog(QDialog *parent, QString name, QString server, QString key, QStringList _otherNames)
+OutputDialog::OutputDialog(QDialog *parent, QString name, QString server, QString key, QStringList _otherNames,
+			   bool _keychainStored)
 	: QDialog(parent),
-	  otherNames(_otherNames)
+	  otherNames(_otherNames),
+	  keychainStored(_keychainStored)
 {
 
 	// Load the services from rtmp-services plugin

--- a/output-dialog.hpp
+++ b/output-dialog.hpp
@@ -55,10 +55,12 @@ private:
 
 	QStackedWidget *stackedWidget;
 	QStringList otherNames;
+	bool keychainStored = false;
 
 public:
 	OutputDialog(QDialog *parent, QStringList otherNames);
-	OutputDialog(QDialog *parent, QString name, QString server, QString key, QStringList otherNames);
+	OutputDialog(QDialog *parent, QString name, QString server, QString key, QStringList otherNames,
+		     bool keychainStored = false);
 	~OutputDialog();
 
 	QString outputName;


### PR DESCRIPTION
Stream keys are currently stored in plaintext in the plugin config JSON file. On macOS, this adds optional support for storing them in the system Keychain instead.

### What it does

- Adds `keychain-helper.mm` wrapping the macOS Security framework (`SecItemAdd`/`SecItemCopyMatching`/`SecItemDelete`) with no-op stubs for other platforms
- On save, if Keychain storage is enabled, stream keys are moved from the config file into the Keychain and replaced with a `keychain_service` reference
- On stream start, keys are retrieved from the Keychain on-demand — they are never loaded into memory at config load time
- The edit dialog shows a placeholder ("Stream key saved in Keychain") instead of the actual key

### Opt-in

A checkbox on the General settings page ("Store stream keys securely in macOS Keychain") controls the feature. It defaults to off. The setting is persisted in `config.json` as `keychain_enabled`. The checkbox only appears on macOS builds (`#ifdef __APPLE__`).

### Use case

Users who multistream often have multiple stream keys in their OBS config. If that file is backed up, shared, or accessed by other software, the keys are exposed. Keychain storage keeps them behind the OS credential store with access control, so they don't sit in a readable JSON file on disk.