### PR TITLE
Add obs-websocket vendor for remote output control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	output-dialog.hpp
 	stream-key-input.hpp
     multistream.hpp
+	obs-websocket-api.h
 	file-updater.h)
 
 if(BUILD_OUT_OF_TREE)

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -11,7 +11,10 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QScrollArea>
+#include <QThread>
+#include <QUrl>
 #include <QVBoxLayout>
+#include <atomic>
 #include <util/config-file.h>
 #include <util/platform.h>
 
@@ -26,6 +29,11 @@ OBS_MODULE_USE_DEFAULT_LOCALE("aitum-multistream", "en-US")
 static MultistreamDock *multistream_dock = nullptr;
 
 static obs_websocket_vendor websocket_vendor = nullptr;
+
+// Set at the top of obs_module_unload. Vendor callbacks arrive on obs-websocket's
+// thread and must stop hopping to the UI thread once it has stopped pumping
+// events, or a blocking hop parks forever and OBS hangs with no window.
+static std::atomic<bool> vendor_shutting_down{false};
 
 update_info_t *version_update_info = nullptr;
 
@@ -65,33 +73,49 @@ bool obs_module_load(void)
 }
 
 // ---- obs-websocket vendor ("aitum-multistream") -------------------------
-// Mirrors the vendor the Vertical Canvas plugin ships: reads answer directly
-// (blocking hop to the UI thread), actions are queued fire-and-forget so the
-// websocket thread never waits on encoder setup. Stream keys are never
-// included in any response.
+// Mirrors the vendor the Vertical Canvas plugin ships. Every request runs the
+// dock work on the UI thread and waits for the result, so the reply reports
+// what actually happened rather than just that the request was posted. Stream
+// keys are never included in any response.
+
+// Runs fn on the dock's thread and waits for it. Returns false when there is no
+// dock to run it on, which is the caller's cue to answer with an error rather
+// than a misleading success.
+template<typename Fn> static bool vendor_run_on_dock(Fn &&fn)
+{
+	// Past this point the UI thread is on its way out and may already have
+	// stopped pumping events; a blocking hop would never return.
+	if (vendor_shutting_down.load())
+		return false;
+	MultistreamDock *dock = multistream_dock;
+	if (!dock)
+		return false;
+	// A blocking queued connection to our own thread deadlocks instantly.
+	// Reachable if anything calls obs_websocket_call_request() from the UI thread.
+	if (QThread::currentThread() == dock->thread()) {
+		fn(dock);
+		return true;
+	}
+	return QMetaObject::invokeMethod(
+		dock, [dock, &fn] { fn(dock); }, Qt::BlockingQueuedConnection);
+}
 
 static void vendor_request_status(obs_data_t *request_data, obs_data_t *response_data, void *)
 {
 	UNUSED_PARAMETER(request_data);
-	if (!multistream_dock) {
+	if (!vendor_run_on_dock([response_data](MultistreamDock *dock) { dock->FillStatus(response_data); })) {
 		obs_data_set_bool(response_data, "success", false);
-		return;
+		obs_data_set_string(response_data, "error", "dock not loaded");
 	}
-	QMetaObject::invokeMethod(
-		multistream_dock, [response_data] { multistream_dock->FillStatus(response_data); },
-		Qt::BlockingQueuedConnection);
 }
 
 static void vendor_request_get_outputs(obs_data_t *request_data, obs_data_t *response_data, void *)
 {
 	UNUSED_PARAMETER(request_data);
-	if (!multistream_dock) {
+	if (!vendor_run_on_dock([response_data](MultistreamDock *dock) { dock->FillOutputs(response_data); })) {
 		obs_data_set_bool(response_data, "success", false);
-		return;
+		obs_data_set_string(response_data, "error", "dock not loaded");
 	}
-	QMetaObject::invokeMethod(
-		multistream_dock, [response_data] { multistream_dock->FillOutputs(response_data); },
-		Qt::BlockingQueuedConnection);
 }
 
 enum class VendorOutputAction { Start, Stop, StartVertical, StopVertical };
@@ -104,35 +128,33 @@ static void vendor_request_output_action(obs_data_t *request_data, obs_data_t *r
 		obs_data_set_string(response_data, "error", "'name' not set");
 		return;
 	}
-	if (!multistream_dock) {
+	QString qname = QString::fromUtf8(name);
+	QString error;
+	bool ok = false;
+	bool ran = vendor_run_on_dock([&](MultistreamDock *dock) {
+		switch (action) {
+		case VendorOutputAction::Start:
+			ok = dock->RemoteStartOutput(qname, error);
+			break;
+		case VendorOutputAction::Stop:
+			ok = dock->RemoteStopOutput(qname, error);
+			break;
+		case VendorOutputAction::StartVertical:
+			ok = dock->RemoteStartVerticalOutput(qname, error);
+			break;
+		case VendorOutputAction::StopVertical:
+			ok = dock->RemoteStopVerticalOutput(qname, error);
+			break;
+		}
+	});
+	if (!ran) {
 		obs_data_set_bool(response_data, "success", false);
 		obs_data_set_string(response_data, "error", "dock not loaded");
 		return;
 	}
-	QString qname = QString::fromUtf8(name);
-	QMetaObject::invokeMethod(
-		multistream_dock,
-		[qname, action] {
-			if (!multistream_dock)
-				return;
-			switch (action) {
-			case VendorOutputAction::Start:
-				multistream_dock->RemoteStartOutput(qname);
-				break;
-			case VendorOutputAction::Stop:
-				multistream_dock->RemoteStopOutput(qname);
-				break;
-			case VendorOutputAction::StartVertical:
-				multistream_dock->RemoteStartVerticalOutput(qname);
-				break;
-			case VendorOutputAction::StopVertical:
-				multistream_dock->RemoteStopVerticalOutput(qname);
-				break;
-			}
-		},
-		Qt::QueuedConnection);
-	obs_data_set_bool(response_data, "success", true);
-	obs_data_set_bool(response_data, "accepted", true);
+	obs_data_set_bool(response_data, "success", ok);
+	if (!ok)
+		obs_data_set_string(response_data, "error", error.toUtf8().constData());
 }
 
 static void vendor_request_start_output(obs_data_t *rd, obs_data_t *res, void *)
@@ -173,15 +195,17 @@ void obs_module_post_load()
 
 void obs_module_unload()
 {
-	if (websocket_vendor) {
-		obs_websocket_vendor_unregister_request(websocket_vendor, "status");
-		obs_websocket_vendor_unregister_request(websocket_vendor, "get_outputs");
-		obs_websocket_vendor_unregister_request(websocket_vendor, "start_output");
-		obs_websocket_vendor_unregister_request(websocket_vendor, "stop_output");
-		obs_websocket_vendor_unregister_request(websocket_vendor, "start_vertical_output");
-		obs_websocket_vendor_unregister_request(websocket_vendor, "stop_vertical_output");
-		websocket_vendor = nullptr;
-	}
+	// Stop answering vendor requests before the dock goes away. Deliberately
+	// NOT calling obs_websocket_vendor_unregister_request() here: those route
+	// through the proc handler cached in obs-websocket-api.h during
+	// obs_module_post_load, and modules tear down in reverse load order, so
+	// obs-websocket has usually already unloaded and destroyed that handler by
+	// this point -- the call then faults inside proc_handler_call and takes the
+	// rest of obs_shutdown with it. obs-websocket drops all vendors during its
+	// own shutdown, so there is nothing to clean up here.
+	vendor_shutting_down.store(true);
+	websocket_vendor = nullptr;
+
 	if (version_update_info) {
 		update_info_destroy(version_update_info);
 		version_update_info = nullptr;
@@ -1315,20 +1339,47 @@ void MultistreamDock::LoadVerticalOutputs(bool firstLoad)
 }
 
 // ---- Remote control (obs-websocket vendor) -------------------------------
-// All of these run on the UI thread and never show dialogs.
+// All of these run on the UI thread and never show dialogs. They return whether
+// the action actually happened, so the websocket reply can report a failure
+// instead of the bare acknowledgement the caller would otherwise get.
 
-void MultistreamDock::RemoteStartOutput(const QString &name)
+bool MultistreamDock::HasConfiguredOutput(const QString &name)
 {
 	if (!current_config)
-		return;
+		return false;
+	bool found = false;
+	auto configOutputs = obs_data_get_array(current_config, "outputs");
+	auto count = obs_data_array_count(configOutputs);
+	for (size_t i = 0; i < count; i++) {
+		auto item = obs_data_array_item(configOutputs, i);
+		if (!item)
+			continue;
+		if (name == QString::fromUtf8(obs_data_get_string(item, "name")))
+			found = true;
+		obs_data_release(item);
+		if (found)
+			break;
+	}
+	obs_data_array_release(configOutputs);
+	return found;
+}
+
+bool MultistreamDock::RemoteStartOutput(const QString &name, QString &error)
+{
+	if (!current_config) {
+		error = QStringLiteral("no configuration loaded");
+		return false;
+	}
 	auto nameUtf8 = name.toUtf8();
 	// Already running? The dock click path and this method both run on the UI
-	// thread, so this check is the authoritative double-start guard.
+	// thread, so this check is the authoritative double-start guard. Starting
+	// something that is already started is the state the caller asked for, so
+	// report success rather than an error.
 	for (auto it = outputs.begin(); it != outputs.end(); it++) {
 		if (std::get<std::string>(*it) == nameUtf8.constData() &&
 		    obs_output_active(std::get<obs_output_t *>(*it))) {
 			blog(LOG_INFO, "[Aitum Multistream] remote start ignored, '%s' already active", nameUtf8.constData());
-			return;
+			return true;
 		}
 	}
 	obs_data_t *found = nullptr;
@@ -1347,7 +1398,8 @@ void MultistreamDock::RemoteStartOutput(const QString &name)
 	obs_data_array_release(outputs2);
 	if (!found) {
 		blog(LOG_WARNING, "[Aitum Multistream] remote start: no output named '%s'", nameUtf8.constData());
-		return;
+		error = QStringLiteral("no output named '%1'").arg(name);
+		return false;
 	}
 	// The row widget's toggle button — the signal callbacks require it.
 	QPushButton *streamButton = nullptr;
@@ -1361,32 +1413,63 @@ void MultistreamDock::RemoteStartOutput(const QString &name)
 	if (!streamButton) {
 		blog(LOG_WARNING, "[Aitum Multistream] remote start: no dock row for '%s'", nameUtf8.constData());
 		obs_data_release(found);
-		return;
+		error = QStringLiteral("no dock row for '%1'").arg(name);
+		return false;
 	}
 	blog(LOG_INFO, "[Aitum Multistream] remote start stream '%s'", nameUtf8.constData());
-	if (StartOutput(found, streamButton, false)) {
-		streamButton->setChecked(true);
-	} else {
-		streamButton->setChecked(false);
-	}
+	bool started = StartOutput(found, streamButton, false);
+	streamButton->setChecked(started);
 	outputButtonStyle(streamButton);
 	obs_data_release(found);
+	if (!started) {
+		// StartOutput logs the specific reason; the common one by far is an
+		// output that borrows the main stream's encoders while main is down.
+		error = QStringLiteral("could not start '%1' - the usual cause is the main stream "
+				       "not being live; see the OBS log for the exact reason")
+				.arg(name);
+		return false;
+	}
+	return true;
 }
 
-void MultistreamDock::RemoteStopOutput(const QString &name)
+bool MultistreamDock::RemoteStopOutput(const QString &name, QString &error)
 {
 	auto nameUtf8 = name.toUtf8();
+	bool stopped = false;
 	for (auto it = outputs.begin(); it != outputs.end(); it++) {
 		if (std::get<std::string>(*it) != nameUtf8.constData())
 			continue;
 		blog(LOG_INFO, "[Aitum Multistream] remote stop stream '%s'", nameUtf8.constData());
+		// Hold a reference for the trip to the graphics thread: the output's
+		// own stop signal can land first and drop the last reference, leaving
+		// the queued task to call obs_output_stop on freed memory. Reachable
+		// when a remote stop races the stream dropping on its own.
+		auto output = obs_output_get_ref(std::get<obs_output_t *>(*it));
+		if (!output)
+			continue;
 		obs_queue_task(
-			OBS_TASK_GRAPHICS, [](void *param) { obs_output_stop((obs_output_t *)param); },
-			std::get<obs_output_t *>(*it), false);
+			OBS_TASK_GRAPHICS,
+			[](void *param) {
+				auto o = (obs_output_t *)param;
+				obs_output_stop(o);
+				obs_output_release(o);
+			},
+			output, false);
+		stopped = true;
 	}
+	if (stopped)
+		return true;
+	// Nothing running under that name. If it is a real output it is simply
+	// already stopped, which is what the caller asked for; if it is not, the
+	// caller has the name wrong and needs to hear about it.
+	if (HasConfiguredOutput(name))
+		return true;
+	blog(LOG_WARNING, "[Aitum Multistream] remote stop: no output named '%s'", nameUtf8.constData());
+	error = QStringLiteral("no output named '%1'").arg(name);
+	return false;
 }
 
-void MultistreamDock::RemoteStartVerticalOutput(const QString &name)
+bool MultistreamDock::RemoteStartVerticalOutput(const QString &name, QString &error)
 {
 	auto ph = obs_get_proc_handler();
 	struct calldata cd;
@@ -1396,7 +1479,8 @@ void MultistreamDock::RemoteStartVerticalOutput(const QString &name)
 	calldata_free(&cd);
 	if (!called) {
 		blog(LOG_WARNING, "[Aitum Multistream] remote vertical start failed (no vertical canvas)");
-		return;
+		error = QStringLiteral("vertical canvas not available");
+		return false;
 	}
 	blog(LOG_INFO, "[Aitum Multistream] remote start vertical stream '%s'", name.toUtf8().constData());
 	for (int i = 0; i < verticalCanvasOutputLayout->count(); i++) {
@@ -1409,9 +1493,10 @@ void MultistreamDock::RemoteStartVerticalOutput(const QString &name)
 			break;
 		}
 	}
+	return true;
 }
 
-void MultistreamDock::RemoteStopVerticalOutput(const QString &name)
+bool MultistreamDock::RemoteStopVerticalOutput(const QString &name, QString &error)
 {
 	auto ph = obs_get_proc_handler();
 	struct calldata cd;
@@ -1419,8 +1504,11 @@ void MultistreamDock::RemoteStopVerticalOutput(const QString &name)
 	calldata_set_string(&cd, "name", name.toUtf8().constData());
 	bool called = proc_handler_call(ph, "aitum_vertical_stop_stream_output", &cd);
 	calldata_free(&cd);
-	if (!called)
-		return;
+	if (!called) {
+		blog(LOG_WARNING, "[Aitum Multistream] remote vertical stop failed (no vertical canvas)");
+		error = QStringLiteral("vertical canvas not available");
+		return false;
+	}
 	blog(LOG_INFO, "[Aitum Multistream] remote stop vertical stream '%s'", name.toUtf8().constData());
 	for (int i = 0; i < verticalCanvasOutputLayout->count(); i++) {
 		auto item = verticalCanvasOutputLayout->itemAt(i);
@@ -1432,6 +1520,7 @@ void MultistreamDock::RemoteStopVerticalOutput(const QString &name)
 			break;
 		}
 	}
+	return true;
 }
 
 void MultistreamDock::FillStatus(obs_data_t *response_data)
@@ -1473,9 +1562,22 @@ void MultistreamDock::FillOutputs(obs_data_t *response_data)
 					break;
 				}
 			}
+			// Only scheme://host:port goes out. The separate stream_key field
+			// is never included, but for WHIP/SRT/RIST and some CDNs the
+			// credential lives inside the ingest URL itself (?streamid=,
+			// ?passphrase=, a token in the path), and the config dialog
+			// accepts a whole URL pasted into the server box. Host and port
+			// are all a client needs to identify the platform.
+			QString safeServer;
+			if (server && *server) {
+				QUrl parsed(QString::fromUtf8(server));
+				if (parsed.isValid() && !parsed.host().isEmpty())
+					safeServer = parsed.toString(QUrl::RemoveUserInfo | QUrl::RemovePath |
+								     QUrl::RemoveQuery | QUrl::RemoveFragment);
+			}
 			auto entry = obs_data_create();
 			obs_data_set_string(entry, "name", name);
-			obs_data_set_string(entry, "stream_server", server ? server : "");
+			obs_data_set_string(entry, "stream_server", safeServer.toUtf8().constData());
 			obs_data_set_bool(entry, "advanced", advanced);
 			obs_data_set_bool(entry, "requires_main", requires_main);
 			obs_data_set_bool(entry, "active", active);

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -3,6 +3,7 @@
 #include "obs-module.h"
 #include "version.h"
 #include <obs-frontend-api.h>
+#include "obs-websocket-api.h"
 #include <QDesktopServices>
 #include <QGroupBox>
 #include <QLabel>
@@ -23,6 +24,8 @@ OBS_MODULE_AUTHOR("Aitum");
 OBS_MODULE_USE_DEFAULT_LOCALE("aitum-multistream", "en-US")
 
 static MultistreamDock *multistream_dock = nullptr;
+
+static obs_websocket_vendor websocket_vendor = nullptr;
 
 update_info_t *version_update_info = nullptr;
 
@@ -61,20 +64,131 @@ bool obs_module_load(void)
 	return true;
 }
 
+// ---- obs-websocket vendor ("aitum-multistream") -------------------------
+// Mirrors the vendor the Vertical Canvas plugin ships: reads answer directly
+// (blocking hop to the UI thread), actions are queued fire-and-forget so the
+// websocket thread never waits on encoder setup. Stream keys are never
+// included in any response.
+
+static void vendor_request_status(obs_data_t *request_data, obs_data_t *response_data, void *)
+{
+	UNUSED_PARAMETER(request_data);
+	if (!multistream_dock) {
+		obs_data_set_bool(response_data, "success", false);
+		return;
+	}
+	QMetaObject::invokeMethod(
+		multistream_dock, [response_data] { multistream_dock->FillStatus(response_data); },
+		Qt::BlockingQueuedConnection);
+}
+
+static void vendor_request_get_outputs(obs_data_t *request_data, obs_data_t *response_data, void *)
+{
+	UNUSED_PARAMETER(request_data);
+	if (!multistream_dock) {
+		obs_data_set_bool(response_data, "success", false);
+		return;
+	}
+	QMetaObject::invokeMethod(
+		multistream_dock, [response_data] { multistream_dock->FillOutputs(response_data); },
+		Qt::BlockingQueuedConnection);
+}
+
+enum class VendorOutputAction { Start, Stop, StartVertical, StopVertical };
+
+static void vendor_request_output_action(obs_data_t *request_data, obs_data_t *response_data, VendorOutputAction action)
+{
+	const char *name = obs_data_get_string(request_data, "name");
+	if (!name || !*name) {
+		obs_data_set_bool(response_data, "success", false);
+		obs_data_set_string(response_data, "error", "'name' not set");
+		return;
+	}
+	if (!multistream_dock) {
+		obs_data_set_bool(response_data, "success", false);
+		obs_data_set_string(response_data, "error", "dock not loaded");
+		return;
+	}
+	QString qname = QString::fromUtf8(name);
+	QMetaObject::invokeMethod(
+		multistream_dock,
+		[qname, action] {
+			if (!multistream_dock)
+				return;
+			switch (action) {
+			case VendorOutputAction::Start:
+				multistream_dock->RemoteStartOutput(qname);
+				break;
+			case VendorOutputAction::Stop:
+				multistream_dock->RemoteStopOutput(qname);
+				break;
+			case VendorOutputAction::StartVertical:
+				multistream_dock->RemoteStartVerticalOutput(qname);
+				break;
+			case VendorOutputAction::StopVertical:
+				multistream_dock->RemoteStopVerticalOutput(qname);
+				break;
+			}
+		},
+		Qt::QueuedConnection);
+	obs_data_set_bool(response_data, "success", true);
+	obs_data_set_bool(response_data, "accepted", true);
+}
+
+static void vendor_request_start_output(obs_data_t *rd, obs_data_t *res, void *)
+{
+	vendor_request_output_action(rd, res, VendorOutputAction::Start);
+}
+static void vendor_request_stop_output(obs_data_t *rd, obs_data_t *res, void *)
+{
+	vendor_request_output_action(rd, res, VendorOutputAction::Stop);
+}
+static void vendor_request_start_vertical_output(obs_data_t *rd, obs_data_t *res, void *)
+{
+	vendor_request_output_action(rd, res, VendorOutputAction::StartVertical);
+}
+static void vendor_request_stop_vertical_output(obs_data_t *rd, obs_data_t *res, void *)
+{
+	vendor_request_output_action(rd, res, VendorOutputAction::StopVertical);
+}
+
 void obs_module_post_load()
 {
 	if (multistream_dock)
 		multistream_dock->LoadVerticalOutputs(true);
+
+	websocket_vendor = obs_websocket_register_vendor("aitum-multistream");
+	if (websocket_vendor) {
+		obs_websocket_vendor_register_request(websocket_vendor, "status", vendor_request_status, nullptr);
+		obs_websocket_vendor_register_request(websocket_vendor, "get_outputs", vendor_request_get_outputs, nullptr);
+		obs_websocket_vendor_register_request(websocket_vendor, "start_output", vendor_request_start_output, nullptr);
+		obs_websocket_vendor_register_request(websocket_vendor, "stop_output", vendor_request_stop_output, nullptr);
+		obs_websocket_vendor_register_request(websocket_vendor, "start_vertical_output",
+						      vendor_request_start_vertical_output, nullptr);
+		obs_websocket_vendor_register_request(websocket_vendor, "stop_vertical_output",
+						      vendor_request_stop_vertical_output, nullptr);
+		blog(LOG_INFO, "[Aitum Multistream] registered obs-websocket vendor 'aitum-multistream'");
+	}
 }
 
 void obs_module_unload()
 {
+	if (websocket_vendor) {
+		obs_websocket_vendor_unregister_request(websocket_vendor, "status");
+		obs_websocket_vendor_unregister_request(websocket_vendor, "get_outputs");
+		obs_websocket_vendor_unregister_request(websocket_vendor, "start_output");
+		obs_websocket_vendor_unregister_request(websocket_vendor, "stop_output");
+		obs_websocket_vendor_unregister_request(websocket_vendor, "start_vertical_output");
+		obs_websocket_vendor_unregister_request(websocket_vendor, "stop_vertical_output");
+		websocket_vendor = nullptr;
+	}
 	if (version_update_info) {
 		update_info_destroy(version_update_info);
 		version_update_info = nullptr;
 	}
 	if (multistream_dock) {
 		delete multistream_dock;
+		multistream_dock = nullptr;
 	}
 }
 
@@ -820,13 +934,13 @@ void MultistreamDock::SaveSettings()
 	bfree(path);
 }
 
-bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButton)
+bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButton, bool interactive)
 {
 	if (!settings)
 		return false;
 
 	bool warnBeforeStreamStart = config_get_bool(get_user_config(), "BasicWindow", "WarnBeforeStartingStream");
-	if (warnBeforeStreamStart && isVisible()) {
+	if (interactive && warnBeforeStreamStart && isVisible()) {
 		auto button = QMessageBox::question(this, QString::fromUtf8(obs_frontend_get_locale_string("ConfirmStart.Title")),
 						    QString::fromUtf8(obs_frontend_get_locale_string("ConfirmStart.Text")),
 						    QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
@@ -860,8 +974,9 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				obs_output_release(main_output);
 				blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 				     obs_data_get_string(settings, "name"));
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-						     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+				if (interactive)
+					QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
+							     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
 				return false;
 			}
 			auto vei = (int)obs_data_get_int(settings, "video_encoder_index");
@@ -871,8 +986,10 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				blog(LOG_WARNING,
 				     "[Aitum Multistream] failed to start stream '%s' because encoder index %d was not found",
 				     obs_data_get_string(settings, "name"), vei);
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
-						     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
+				if (interactive)
+					QMessageBox::warning(this,
+							     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
+							     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
 				return false;
 			}
 		} else {
@@ -907,8 +1024,9 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				obs_output_release(main_output);
 				blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 				     obs_data_get_string(settings, "name"));
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-						     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+				if (interactive)
+					QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
+							     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
 				return false;
 			}
 			auto aei = (int)obs_data_get_int(settings, "audio_encoder_index");
@@ -918,8 +1036,10 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				blog(LOG_WARNING,
 				     "[Aitum Multistream] failed to start stream '%s' because encoder index %d was not found",
 				     obs_data_get_string(settings, "name"), aei);
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
-						     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
+				if (interactive)
+					QMessageBox::warning(this,
+							     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
+							     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
 				return false;
 			}
 		} else {
@@ -944,8 +1064,9 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 			obs_output_release(main_output);
 			blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 			     obs_data_get_string(settings, "name"));
-			QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-					     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+			if (interactive)
+				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
+						     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
 			return false;
 		}
 
@@ -1191,6 +1312,222 @@ void MultistreamDock::LoadVerticalOutputs(bool firstLoad)
 			d->LoadOutput(data2, true);
 		},
 		this);
+}
+
+// ---- Remote control (obs-websocket vendor) -------------------------------
+// All of these run on the UI thread and never show dialogs.
+
+void MultistreamDock::RemoteStartOutput(const QString &name)
+{
+	if (!current_config)
+		return;
+	auto nameUtf8 = name.toUtf8();
+	// Already running? The dock click path and this method both run on the UI
+	// thread, so this check is the authoritative double-start guard.
+	for (auto it = outputs.begin(); it != outputs.end(); it++) {
+		if (std::get<std::string>(*it) == nameUtf8.constData() &&
+		    obs_output_active(std::get<obs_output_t *>(*it))) {
+			blog(LOG_INFO, "[Aitum Multistream] remote start ignored, '%s' already active", nameUtf8.constData());
+			return;
+		}
+	}
+	obs_data_t *found = nullptr;
+	auto outputs2 = obs_data_get_array(current_config, "outputs");
+	auto count = obs_data_array_count(outputs2);
+	for (size_t i = 0; i < count; i++) {
+		auto item = obs_data_array_item(outputs2, i);
+		if (!item)
+			continue;
+		if (name == QString::fromUtf8(obs_data_get_string(item, "name"))) {
+			found = item;
+			break;
+		}
+		obs_data_release(item);
+	}
+	obs_data_array_release(outputs2);
+	if (!found) {
+		blog(LOG_WARNING, "[Aitum Multistream] remote start: no output named '%s'", nameUtf8.constData());
+		return;
+	}
+	// The row widget's toggle button — the signal callbacks require it.
+	QPushButton *streamButton = nullptr;
+	for (int i = 1; i < mainCanvasOutputLayout->count(); i++) {
+		auto item = mainCanvasOutputLayout->itemAt(i);
+		if (item && item->widget() && item->widget()->objectName() == name) {
+			streamButton = item->widget()->findChild<QPushButton *>(QStringLiteral("canvasStream"));
+			break;
+		}
+	}
+	if (!streamButton) {
+		blog(LOG_WARNING, "[Aitum Multistream] remote start: no dock row for '%s'", nameUtf8.constData());
+		obs_data_release(found);
+		return;
+	}
+	blog(LOG_INFO, "[Aitum Multistream] remote start stream '%s'", nameUtf8.constData());
+	if (StartOutput(found, streamButton, false)) {
+		streamButton->setChecked(true);
+	} else {
+		streamButton->setChecked(false);
+	}
+	outputButtonStyle(streamButton);
+	obs_data_release(found);
+}
+
+void MultistreamDock::RemoteStopOutput(const QString &name)
+{
+	auto nameUtf8 = name.toUtf8();
+	for (auto it = outputs.begin(); it != outputs.end(); it++) {
+		if (std::get<std::string>(*it) != nameUtf8.constData())
+			continue;
+		blog(LOG_INFO, "[Aitum Multistream] remote stop stream '%s'", nameUtf8.constData());
+		obs_queue_task(
+			OBS_TASK_GRAPHICS, [](void *param) { obs_output_stop((obs_output_t *)param); },
+			std::get<obs_output_t *>(*it), false);
+	}
+}
+
+void MultistreamDock::RemoteStartVerticalOutput(const QString &name)
+{
+	auto ph = obs_get_proc_handler();
+	struct calldata cd;
+	calldata_init(&cd);
+	calldata_set_string(&cd, "name", name.toUtf8().constData());
+	bool called = proc_handler_call(ph, "aitum_vertical_start_stream_output", &cd);
+	calldata_free(&cd);
+	if (!called) {
+		blog(LOG_WARNING, "[Aitum Multistream] remote vertical start failed (no vertical canvas)");
+		return;
+	}
+	blog(LOG_INFO, "[Aitum Multistream] remote start vertical stream '%s'", name.toUtf8().constData());
+	for (int i = 0; i < verticalCanvasOutputLayout->count(); i++) {
+		auto item = verticalCanvasOutputLayout->itemAt(i);
+		if (item && item->widget() && item->widget()->objectName() == name) {
+			if (auto button = item->widget()->findChild<QPushButton *>(QStringLiteral("canvasStream"))) {
+				button->setChecked(true);
+				outputButtonStyle(button);
+			}
+			break;
+		}
+	}
+}
+
+void MultistreamDock::RemoteStopVerticalOutput(const QString &name)
+{
+	auto ph = obs_get_proc_handler();
+	struct calldata cd;
+	calldata_init(&cd);
+	calldata_set_string(&cd, "name", name.toUtf8().constData());
+	bool called = proc_handler_call(ph, "aitum_vertical_stop_stream_output", &cd);
+	calldata_free(&cd);
+	if (!called)
+		return;
+	blog(LOG_INFO, "[Aitum Multistream] remote stop vertical stream '%s'", name.toUtf8().constData());
+	for (int i = 0; i < verticalCanvasOutputLayout->count(); i++) {
+		auto item = verticalCanvasOutputLayout->itemAt(i);
+		if (item && item->widget() && item->widget()->objectName() == name) {
+			if (auto button = item->widget()->findChild<QPushButton *>(QStringLiteral("canvasStream"))) {
+				button->setChecked(false);
+				outputButtonStyle(button);
+			}
+			break;
+		}
+	}
+}
+
+void MultistreamDock::FillStatus(obs_data_t *response_data)
+{
+	obs_data_set_bool(response_data, "success", true);
+	obs_data_set_string(response_data, "version", PROJECT_VERSION);
+	obs_data_set_int(response_data, "api", 1);
+	obs_data_set_bool(response_data, "main_active", obs_frontend_streaming_active());
+}
+
+void MultistreamDock::FillOutputs(obs_data_t *response_data)
+{
+	auto arr = obs_data_array_create();
+	if (current_config) {
+		auto outputs2 = obs_data_get_array(current_config, "outputs");
+		auto count = obs_data_array_count(outputs2);
+		for (size_t i = 0; i < count; i++) {
+			auto item = obs_data_array_item(outputs2, i);
+			if (!item)
+				continue;
+			auto name = obs_data_get_string(item, "name");
+			if (!name || !*name) {
+				obs_data_release(item);
+				continue;
+			}
+			auto server = obs_data_get_string(item, "stream_server");
+			if (!server || !*server)
+				server = obs_data_get_string(item, "server");
+			auto advanced = obs_data_get_bool(item, "advanced");
+			auto venc = obs_data_get_string(item, "video_encoder");
+			auto aenc = obs_data_get_string(item, "audio_encoder");
+			// Borrowing any main-stream encoder means the output can only
+			// start while the main stream is active.
+			bool requires_main = !advanced || !venc || !*venc || !aenc || !*aenc;
+			bool active = false;
+			for (auto it = outputs.begin(); it != outputs.end(); it++) {
+				if (std::get<std::string>(*it) == name) {
+					active = obs_output_active(std::get<obs_output_t *>(*it));
+					break;
+				}
+			}
+			auto entry = obs_data_create();
+			obs_data_set_string(entry, "name", name);
+			obs_data_set_string(entry, "stream_server", server ? server : "");
+			obs_data_set_bool(entry, "advanced", advanced);
+			obs_data_set_bool(entry, "requires_main", requires_main);
+			obs_data_set_bool(entry, "active", active);
+			obs_data_array_push_back(arr, entry);
+			obs_data_release(entry);
+			obs_data_release(item);
+		}
+		obs_data_array_release(outputs2);
+	}
+	obs_data_set_array(response_data, "outputs", arr);
+	obs_data_array_release(arr);
+
+	// Vertical canvas outputs (via its in-process API). GetStreamOutput adds
+	// a reference, so release after the active check.
+	auto varr = obs_data_array_create();
+	if (vertical_outputs) {
+		auto ph = obs_get_proc_handler();
+		auto count = obs_data_array_count(vertical_outputs);
+		for (size_t i = 0; i < count; i++) {
+			auto item = obs_data_array_item(vertical_outputs, i);
+			if (!item)
+				continue;
+			auto name = obs_data_get_string(item, "name");
+			if (!name || !*name) {
+				obs_data_release(item);
+				continue;
+			}
+			bool active = false;
+			struct calldata cd;
+			calldata_init(&cd);
+			calldata_set_string(&cd, "name", name);
+			if (proc_handler_call(ph, "aitum_vertical_get_stream_output", &cd)) {
+				auto output = (obs_output_t *)calldata_ptr(&cd, "output");
+				if (output) {
+					active = obs_output_active(output);
+					obs_output_release(output);
+				}
+			}
+			calldata_free(&cd);
+			auto entry = obs_data_create();
+			obs_data_set_string(entry, "name", name);
+			obs_data_set_bool(entry, "active", active);
+			obs_data_array_push_back(varr, entry);
+			obs_data_release(entry);
+			obs_data_release(item);
+		}
+	}
+	obs_data_set_array(response_data, "vertical_outputs", varr);
+	obs_data_array_release(varr);
+
+	obs_data_set_bool(response_data, "success", true);
+	obs_data_set_bool(response_data, "main_active", obs_frontend_streaming_active());
 }
 
 void MultistreamDock::storeMainStreamEncoders()

--- a/multistream.hpp
+++ b/multistream.hpp
@@ -71,13 +71,17 @@ public:
 	void LoadVerticalOutputs(bool firstLoad = true);
 
 	// Remote control via the obs-websocket vendor ("aitum-multistream").
-	// The Remote* methods run on the UI thread (invoked queued from the
-	// websocket thread) and never show dialogs; the Fill* methods run on the
-	// UI thread via a blocking invoke and only read state.
-	Q_INVOKABLE void RemoteStartOutput(const QString &name);
-	Q_INVOKABLE void RemoteStopOutput(const QString &name);
-	Q_INVOKABLE void RemoteStartVerticalOutput(const QString &name);
-	Q_INVOKABLE void RemoteStopVerticalOutput(const QString &name);
+	// All of these run on the UI thread, reached by a blocking invoke from the
+	// websocket thread, and never show dialogs. The Remote* methods report
+	// whether the action actually happened and fill `error` when it did not,
+	// so the websocket reply can say so; the Fill* methods only read state.
+	bool RemoteStartOutput(const QString &name, QString &error);
+	bool RemoteStopOutput(const QString &name, QString &error);
+	bool RemoteStartVerticalOutput(const QString &name, QString &error);
+	bool RemoteStopVerticalOutput(const QString &name, QString &error);
+	// True when the profile config lists an output by this name, whether or not
+	// it is currently running. Distinguishes "already stopped" from a bad name.
+	bool HasConfiguredOutput(const QString &name);
 	void FillStatus(obs_data_t *response_data);
 	void FillOutputs(obs_data_t *response_data);
 };

--- a/multistream.hpp
+++ b/multistream.hpp
@@ -46,7 +46,7 @@ private:
 	void LoadOutput(obs_data_t *data, bool vertical);
 	void SaveSettings();
 
-	bool StartOutput(obs_data_t *settings, QPushButton *streamButton);
+	bool StartOutput(obs_data_t *settings, QPushButton *streamButton, bool interactive = true);
 
 	void outputButtonStyle(QPushButton *button);
 
@@ -69,6 +69,17 @@ public:
 	MultistreamDock(QWidget *parent = nullptr);
 	~MultistreamDock();
 	void LoadVerticalOutputs(bool firstLoad = true);
+
+	// Remote control via the obs-websocket vendor ("aitum-multistream").
+	// The Remote* methods run on the UI thread (invoked queued from the
+	// websocket thread) and never show dialogs; the Fill* methods run on the
+	// UI thread via a blocking invoke and only read state.
+	Q_INVOKABLE void RemoteStartOutput(const QString &name);
+	Q_INVOKABLE void RemoteStopOutput(const QString &name);
+	Q_INVOKABLE void RemoteStartVerticalOutput(const QString &name);
+	Q_INVOKABLE void RemoteStopVerticalOutput(const QString &name);
+	void FillStatus(obs_data_t *response_data);
+	void FillOutputs(obs_data_t *response_data);
 };
 
 class AspectRatioPixmapLabel : public QLabel {

--- a/obs-websocket-api.h
+++ b/obs-websocket-api.h
@@ -1,0 +1,216 @@
+/*
+obs-websocket
+Copyright (C) 2016-2021 Stephane Lepin <stephane.lepin@gmail.com>
+Copyright (C) 2020-2022 Kyle Manning <tt2468@gmail.com>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program. If not, see <https://www.gnu.org/licenses/>
+*/
+
+#ifndef _OBS_WEBSOCKET_API_H
+#define _OBS_WEBSOCKET_API_H
+
+#include <obs.h>
+
+#define OBS_WEBSOCKET_API_VERSION 2
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *obs_websocket_vendor;
+typedef void (*obs_websocket_request_callback_function)(obs_data_t *, obs_data_t *, void *);
+
+struct obs_websocket_request_response {
+	unsigned int status_code;
+	char *comment;
+	char *response_data; // JSON string, because obs_data_t* only supports array<object>, so conversions would break API.
+};
+
+/* ==================== INTERNAL DEFINITIONS ==================== */
+
+struct obs_websocket_request_callback {
+	obs_websocket_request_callback_function callback;
+	void *priv_data;
+};
+
+inline proc_handler_t *_ph;
+
+/* ==================== INTERNAL API FUNCTIONS ==================== */
+
+static inline proc_handler_t *obs_websocket_get_ph(void)
+{
+	proc_handler_t *global_ph = obs_get_proc_handler();
+	assert(global_ph != NULL);
+
+	calldata_t cd = {0};
+	if (!proc_handler_call(global_ph, "obs_websocket_api_get_ph", &cd))
+		blog(LOG_DEBUG, "Unable to fetch obs-websocket proc handler object. obs-websocket not installed?");
+	proc_handler_t *ret = (proc_handler_t *)calldata_ptr(&cd, "ph");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+static inline bool obs_websocket_ensure_ph(void)
+{
+	if (!_ph)
+		_ph = obs_websocket_get_ph();
+	return _ph != NULL;
+}
+
+static inline bool obs_websocket_vendor_run_simple_proc(obs_websocket_vendor vendor, const char *proc_name, calldata_t *cd)
+{
+	if (!obs_websocket_ensure_ph())
+		return false;
+
+	if (!vendor || !proc_name || !strlen(proc_name) || !cd)
+		return false;
+
+	calldata_set_ptr(cd, "vendor", vendor);
+
+	proc_handler_call(_ph, proc_name, cd);
+	return calldata_bool(cd, "success");
+}
+
+/* ==================== GENERAL API FUNCTIONS ==================== */
+
+// Gets the API version built with the obs-websocket plugin
+static inline unsigned int obs_websocket_get_api_version(void)
+{
+	if (!obs_websocket_ensure_ph())
+		return 0;
+
+	calldata_t cd = {0};
+
+	if (!proc_handler_call(_ph, "get_api_version", &cd))
+		return 1; // API v1 does not include get_api_version
+
+	unsigned int ret = (unsigned int)calldata_int(&cd, "version");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Calls an obs-websocket request. Free response with `obs_websocket_request_response_free()`
+static inline obs_websocket_request_response *obs_websocket_call_request(const char *request_type, obs_data_t *request_data = NULL)
+{
+	if (!obs_websocket_ensure_ph())
+		return NULL;
+
+	const char *request_data_string = NULL;
+	if (request_data)
+		request_data_string = obs_data_get_json(request_data);
+
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "request_type", request_type);
+	calldata_set_string(&cd, "request_data", request_data_string);
+
+	proc_handler_call(_ph, "call_request", &cd);
+
+	auto ret = (struct obs_websocket_request_response *)calldata_ptr(&cd, "response");
+
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Free a request response object returned by `obs_websocket_call_request()`
+static inline void obs_websocket_request_response_free(struct obs_websocket_request_response *response)
+{
+	if (!response)
+		return;
+
+	if (response->comment)
+		bfree(response->comment);
+	if (response->response_data)
+		bfree(response->response_data);
+	bfree(response);
+}
+
+/* ==================== VENDOR API FUNCTIONS ==================== */
+
+// ALWAYS CALL ONLY VIA `obs_module_post_load()` CALLBACK!
+// Registers a new "vendor" (Example: obs-ndi)
+static inline obs_websocket_vendor obs_websocket_register_vendor(const char *vendor_name)
+{
+	if (!obs_websocket_ensure_ph())
+		return NULL;
+
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "name", vendor_name);
+
+	proc_handler_call(_ph, "vendor_register", &cd);
+	obs_websocket_vendor ret = calldata_ptr(&cd, "vendor");
+	calldata_free(&cd);
+
+	return ret;
+}
+
+// Registers a new request for a vendor
+static inline bool obs_websocket_vendor_register_request(obs_websocket_vendor vendor, const char *request_type,
+							 obs_websocket_request_callback_function request_callback, void *priv_data)
+{
+	calldata_t cd = {0};
+
+	struct obs_websocket_request_callback cb = {};
+	cb.callback = request_callback;
+	cb.priv_data = priv_data;
+
+	calldata_set_string(&cd, "type", request_type);
+	calldata_set_ptr(&cd, "callback", &cb);
+
+	const bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_request_register", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Unregisters an existing vendor request
+static inline bool obs_websocket_vendor_unregister_request(obs_websocket_vendor vendor, const char *request_type)
+{
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "type", request_type);
+
+	const bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_request_unregister", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+// Does not affect event_data refcount.
+// Emits an event under the vendor's name
+static inline bool obs_websocket_vendor_emit_event(obs_websocket_vendor vendor, const char *event_name, obs_data_t *event_data)
+{
+	calldata_t cd = {0};
+
+	calldata_set_string(&cd, "type", event_name);
+	calldata_set_ptr(&cd, "data", (void *)event_data);
+
+	const bool success = obs_websocket_vendor_run_simple_proc(vendor, "vendor_event_emit", &cd);
+	calldata_free(&cd);
+
+	return success;
+}
+
+/* ==================== END API FUNCTIONS ==================== */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
## What

Registers an obs-websocket vendor **`aitum-multistream`** so external tools (stream decks, companion apps, phone dashboards) can mirror the dock — the same integration pattern Vertical Canvas already ships with its `aitum-vertical-canvas` vendor.

### Requests

| requestType | requestData | response |
|---|---|---|
| `status` | `{}` | `{success, version, api, main_active}` |
| `get_outputs` | `{}` | `{success, main_active, outputs:[{name, stream_server, advanced, requires_main, active}], vertical_outputs:[{name, active}]}` |
| `start_output` / `stop_output` | `{name}` | `{success, accepted}` (fire-and-forget) |
| `start_vertical_output` / `stop_vertical_output` | `{name}` | `{success, accepted}` — bridges the existing `aitum_vertical_*` procs over the websocket |

**Stream keys are never included in any response.**

## How

- Vendor registered in `obs_module_post_load` (obs-websocket loads as a module), requests unregistered on unload; `multistream_dock` is now nulled after delete so late callbacks fail safe.
- Vendor callbacks arrive on the websocket thread: reads (`status`, `get_outputs`) hop to the UI thread with `Qt::BlockingQueuedConnection` and fill the response there; actions post with `Qt::QueuedConnection` and return `accepted` immediately, so the websocket thread never waits on encoder setup.
- `StartOutput` gains a `bool interactive = true` parameter: remote starts skip the `QMessageBox` confirm/warning dialogs (a remote caller cannot click them) while dock-button behavior is completely unchanged. Remote start re-checks "already active by name" on the UI thread, so dock clicks and remote calls cannot double-start an output.
- `RemoteStartOutput` resolves the same config entry and dock button as a click, so button states stay in sync both ways; `get_outputs` releases the ref returned by `aitum_vertical_get_stream_output` (`GetStreamOutput` returns an added ref).

## Why

The dock outputs currently cannot be started from outside OBS at all (they only exist in obs core while running, so generic StartOutput requests cannot reach them). This brings Multistream to parity with Vertical Canvas for remote control. Happy to adjust naming/shape to whatever you prefer.

Tested on Windows (OBS 31, obs-websocket 5.x): vendor registration, `get_outputs` against a live config, remote stop of an active output, and remote start correctly refusing with "main was not started" (no dialog) when the main stream is down.
