### PR TITLE
Start/stop outputs with the main output (rebuild of #17)

### DIFF
--- a/config-dialog.cpp
+++ b/config-dialog.cpp
@@ -924,6 +924,35 @@ void OBSBasicSettings::AddServer(QFormLayout *outputsLayout, obs_data_t *setting
 
 	advancedGroupLayout->addWidget(advancedButton);
 
+	// Not inside advancedTabWidget: that is only shown when "advanced" is ticked,
+	// and "advanced" means this output gets its own encoder. Main canvas only --
+	// vertical outputs are driven by the Aitum Vertical procs, not StartOutput.
+	if (main) {
+		auto startWithMain = new QCheckBox(QString::fromUtf8(obs_module_text("StartWithMainOutput")));
+		startWithMain->setChecked(obs_data_get_bool(settings, "start_w_main"));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+		connect(startWithMain, &QCheckBox::checkStateChanged, [startWithMain, settings] {
+#else
+		connect(startWithMain, &QCheckBox::stateChanged, [startWithMain, settings] {
+#endif
+			obs_data_set_bool(settings, "start_w_main", startWithMain->isChecked());
+		});
+		startWithMain->setToolTip(QString::fromUtf8(obs_module_text("StartWithMainOutputInfo")));
+		advancedGroupLayout->addWidget(startWithMain);
+
+		auto stopWithMain = new QCheckBox(QString::fromUtf8(obs_module_text("StopWithMainOutput")));
+		stopWithMain->setChecked(obs_data_get_bool(settings, "stop_w_main"));
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+		connect(stopWithMain, &QCheckBox::checkStateChanged, [stopWithMain, settings] {
+#else
+		connect(stopWithMain, &QCheckBox::stateChanged, [stopWithMain, settings] {
+#endif
+			obs_data_set_bool(settings, "stop_w_main", stopWithMain->isChecked());
+		});
+		stopWithMain->setToolTip(QString::fromUtf8(obs_module_text("StopWithMainOutputInfo")));
+		advancedGroupLayout->addWidget(stopWithMain);
+	}
+
 	connect(streaming_title, &QToolButton::toggled, [advancedGroup, streaming_title, settings](bool checked) {
 		advancedGroup->setVisible(checked);
 		obs_data_set_bool(settings, "expanded", checked);

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -138,3 +138,9 @@ CustomServer="Server"
 CustomServerInfo="Please enter the server URL provided by the site."
 CustomStreamKey="Stream Key"
 CustomStreamKeyInfo="Please enter your stream key, provide by the site."
+
+# Automation
+StartWithMainOutput="Start with main output"
+StartWithMainOutputInfo="Start this output automatically when the main OBS stream starts."
+StopWithMainOutput="Stop with main output"
+StopWithMainOutputInfo="Stop this output automatically when the main OBS stream stops."

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -83,6 +83,28 @@ const char *obs_module_name(void)
 	return obs_module_text("AitumMultistream");
 }
 
+// Asks an output to stop, from the graphics thread as obs expects.
+//
+// The queued task runs later, so a reference is held for the trip: without one
+// the output's own "stop" signal can land in the meantime, stream_output_stop()
+// drops the plugin's reference, the output is destroyed, and the task then runs
+// against freed memory. obs_output_get_ref() returns null if that already
+// happened, in which case there is nothing left to stop.
+static void StopOutput(obs_output_t *output)
+{
+	output = obs_output_get_ref(output);
+	if (!output)
+		return;
+	obs_queue_task(
+		OBS_TASK_GRAPHICS,
+		[](void *param) {
+			auto o = (obs_output_t *)param;
+			obs_output_stop(o);
+			obs_output_release(o);
+		},
+		output, false);
+}
+
 void RemoveWidget(QWidget *widget);
 
 void RemoveLayoutItem(QLayoutItem *item)
@@ -720,10 +742,7 @@ void MultistreamDock::LoadOutput(obs_data_t *output_data, bool vertical)
 						if (std::get<std::string>(*it) != name2)
 							continue;
 
-						obs_queue_task(
-							OBS_TASK_GRAPHICS,
-							[](void *param) { obs_output_stop((obs_output_t *)param); },
-							std::get<obs_output *>(*it), false);
+						StopOutput(std::get<obs_output_t *>(*it));
 					}
 				} else {
 					streamButton->setChecked(true);
@@ -835,18 +854,36 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 	}
 
 	const char *name = obs_data_get_string(settings, "name");
+	// Replacing an output that is still in the list. The order here matters and
+	// the previous order could free the output twice.
+	//
+	// stream_output_stop() also releases the output and erases its entry, and
+	// obs_output_force_stop() raises "stop" synchronously on this very thread,
+	// so the old code re-entered its own cleanup half way through and then
+	// carried on with an iterator into a vector that had been modified.
+	//
+	// So: unhook the signals first, so the handler cannot run at all; take the
+	// entry out of the vector before anything that can re-enter; and only then
+	// release. The disconnects are unconditional -- gating them on
+	// obs_output_active() misses the whole RTMP connect phase, where the output
+	// is not yet active but its signals are already live.
+	obs_output_t *previous = nullptr;
 	for (auto it = outputs.begin(); it != outputs.end(); it++) {
 		if (std::get<std::string>(*it) != name)
 			continue;
-		auto old = std::get<obs_output_t *>(*it);
-		auto service = obs_output_get_service(old);
-		if (obs_output_active(old)) {
-			obs_output_force_stop(old);
-		}
-		obs_output_release(old);
-		obs_service_release(service);
+		previous = std::get<obs_output_t *>(*it);
+		signal_handler_t *previous_signal = obs_output_get_signal_handler(previous);
+		signal_handler_disconnect(previous_signal, "start", stream_output_start, this);
+		signal_handler_disconnect(previous_signal, "stop", stream_output_stop, this);
 		outputs.erase(it);
 		break;
+	}
+	if (previous) {
+		auto service = obs_output_get_service(previous);
+		if (obs_output_active(previous))
+			obs_output_force_stop(previous);
+		obs_output_release(previous);
+		obs_service_release(service);
 	}
 	obs_encoder_t *venc = nullptr;
 	obs_encoder_t *aenc = nullptr;

--- a/multistream.cpp
+++ b/multistream.cpp
@@ -85,11 +85,10 @@ const char *obs_module_name(void)
 
 // Asks an output to stop, from the graphics thread as obs expects.
 //
-// The queued task runs later, so a reference is held for the trip: without one
-// the output's own "stop" signal can land in the meantime, stream_output_stop()
-// drops the plugin's reference, the output is destroyed, and the task then runs
-// against freed memory. obs_output_get_ref() returns null if that already
-// happened, in which case there is nothing left to stop.
+// Call this on the UI thread with an output still held by `outputs`. The extra
+// reference is for the trip: obs_queue_task runs the task later, and in between
+// the output's own "stop" signal can drop the plugin's reference and destroy
+// it, leaving the task to run against freed memory.
 static void StopOutput(obs_output_t *output)
 {
 	output = obs_output_get_ref(output);
@@ -531,9 +530,33 @@ void MultistreamDock::frontend_event(enum obs_frontend_event event, void *privat
 		md->outputButtonStyle(md->mainStreamButton);
 		md->mainStreamButton->setIcon(md->streamActiveIcon);
 		md->storeMainStreamEncoders();
+
+		// Only STARTED, never STARTING. At STARTING the main output has not
+		// been started yet, so obs_output_active() on it is still false and
+		// every output that borrows a main encoder would be refused. STARTING
+		// is also emitted for main starts that then fail straight away, with
+		// no stop event afterwards to undo it.
+		if (event == OBS_FRONTEND_EVENT_STREAMING_STARTED)
+			md->StartOutputsWithMain();
 	} else if (event == OBS_FRONTEND_EVENT_STREAMING_STOPPING || event == OBS_FRONTEND_EVENT_STREAMING_STOPPED) {
 		md->mainStreamButton->setChecked(false);
 		md->outputButtonStyle(md->mainStreamButton);
+
+		// Only STOPPING: it is the earliest notice, and with OBS's stream
+		// delay enabled STOPPED is held back by the whole delay, which would
+		// leave these outputs running for minutes after the operator pressed
+		// stop.
+		// Both events, not just STOPPING. libobs only raises "stopping" from
+		// obs_output_stop/obs_output_force_stop, so a main stream that drops on
+		// its own -- lost connection, server hang-up -- produces STOPPED with
+		// no STOPPING at all, and these outputs would carry on streaming after
+		// the main one had died. Running twice is harmless: anything stopped at
+		// STOPPING has already left the list by then.
+		//
+		// Note nothing clears pending_auto_stop here. A stop remembered for an
+		// output that is still shaking hands has to outlive the main stream
+		// going down -- that is the whole case it exists for.
+		md->StopOutputsWithMain();
 	}
 }
 
@@ -839,13 +862,121 @@ void MultistreamDock::SaveSettings()
 	bfree(path);
 }
 
-bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButton)
+// ---- Following the main output -------------------------------------------
+// Both of these run on the Qt UI thread, from frontend_event.
+
+// Starts every output configured with "start with main output" that is not
+// already running or connecting.
+void MultistreamDock::StartOutputsWithMain()
+{
+	if (!current_config)
+		return;
+	pending_auto_stop.clear();
+	auto outputs2 = obs_data_get_array(current_config, "outputs");
+	if (!outputs2)
+		return;
+	auto count = obs_data_array_count(outputs2);
+	for (size_t i = 0; i < count; i++) {
+		auto item = obs_data_array_item(outputs2, i);
+		if (!item)
+			continue;
+		auto name = obs_data_get_string(item, "name");
+		if (!obs_data_get_bool(item, "start_w_main") || !name || !*name) {
+			obs_data_release(item);
+			continue;
+		}
+		// An entry in `outputs` means an output object already exists for this
+		// name, so it is running or still connecting. Leave it alone: starting
+		// it again would tear down what the user already had going. Note that
+		// obs_output_active() is not usable as that test, because it stays
+		// false for the whole connect phase.
+		bool busy = false;
+		for (auto it = outputs.begin(); it != outputs.end(); it++) {
+			if (std::get<std::string>(*it) == name) {
+				busy = true;
+				break;
+			}
+		}
+		if (busy) {
+			blog(LOG_INFO, "[Aitum Multistream] '%s' is already running, not starting it with the main output",
+			     name);
+			obs_data_release(item);
+			continue;
+		}
+		QPushButton *streamButton = nullptr;
+		for (int j = 1; j < mainCanvasOutputLayout->count(); j++) {
+			auto layoutItem = mainCanvasOutputLayout->itemAt(j);
+			if (layoutItem && layoutItem->widget() &&
+			    layoutItem->widget()->objectName() == QString::fromUtf8(name)) {
+				streamButton = layoutItem->widget()->findChild<QPushButton *>(QStringLiteral("canvasStream"));
+				break;
+			}
+		}
+		if (!streamButton) {
+			blog(LOG_WARNING, "[Aitum Multistream] no dock row for '%s', not starting it with the main output",
+			     name);
+			obs_data_release(item);
+			continue;
+		}
+		blog(LOG_INFO, "[Aitum Multistream] starting stream '%s' with the main output", name);
+		bool started = StartOutput(item, streamButton, true);
+		streamButton->setChecked(started);
+		outputButtonStyle(streamButton);
+		obs_data_release(item);
+	}
+	obs_data_array_release(outputs2);
+}
+
+// Stops every output configured with "stop with main output".
+void MultistreamDock::StopOutputsWithMain()
+{
+	if (!current_config)
+		return;
+	auto outputs2 = obs_data_get_array(current_config, "outputs");
+	if (!outputs2)
+		return;
+	auto count = obs_data_array_count(outputs2);
+	for (size_t i = 0; i < count; i++) {
+		auto item = obs_data_array_item(outputs2, i);
+		if (!item)
+			continue;
+		auto name = obs_data_get_string(item, "name");
+		if (!obs_data_get_bool(item, "stop_w_main") || !name || !*name) {
+			obs_data_release(item);
+			continue;
+		}
+		for (auto it = outputs.begin(); it != outputs.end(); it++) {
+			if (std::get<std::string>(*it) != name)
+				continue;
+			auto output = std::get<obs_output_t *>(*it);
+			if (obs_output_active(output) || obs_output_reconnecting(output)) {
+				blog(LOG_INFO, "[Aitum Multistream] stopping stream '%s' with the main output", name);
+				StopOutput(output);
+			} else {
+				// Still connecting. obs_output_stop() does nothing for an
+				// output that is neither active nor reconnecting, so asking
+				// now would be silently dropped and the output would go live
+				// after the main stream had already gone down. Remember it and
+				// stop it as soon as it reports that it started.
+				blog(LOG_INFO,
+				     "[Aitum Multistream] '%s' is still connecting, it will be stopped as soon as it starts",
+				     name);
+				pending_auto_stop.insert(name);
+			}
+			break;
+		}
+		obs_data_release(item);
+	}
+	obs_data_array_release(outputs2);
+}
+
+bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButton, bool automatic)
 {
 	if (!settings)
 		return false;
 
 	bool warnBeforeStreamStart = config_get_bool(get_user_config(), "BasicWindow", "WarnBeforeStartingStream");
-	if (warnBeforeStreamStart && isVisible()) {
+	if (!automatic && warnBeforeStreamStart && isVisible()) {
 		auto button = QMessageBox::question(this, QString::fromUtf8(obs_frontend_get_locale_string("ConfirmStart.Title")),
 						    QString::fromUtf8(obs_frontend_get_locale_string("ConfirmStart.Text")),
 						    QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
@@ -853,7 +984,22 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 			return false;
 	}
 
+	// Every failure below is reported through this. An automatic start shows
+	// nothing: there may be nobody at the machine to dismiss it, and one modal
+	// per configured output would wedge OBS entirely. The log line is written
+	// either way, since on an automatic start it is the only feedback there is.
+	auto reportFailure = [this, automatic](const char *locale_key) {
+		if (automatic)
+			return;
+		auto text = QString::fromUtf8(obs_module_text(locale_key));
+		QMessageBox::warning(this, text, text);
+	};
+
 	const char *name = obs_data_get_string(settings, "name");
+	// Starting this name supersedes any stop remembered for it while it was
+	// connecting, whoever asked for the start. Without this the deferred stop
+	// would fire against whatever output holds the name later and kill it.
+	pending_auto_stop.erase(name);
 	// Replacing an output that is still in the list. The order here matters and
 	// the previous order could free the output twice.
 	//
@@ -897,8 +1043,7 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				obs_output_release(main_output);
 				blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 				     obs_data_get_string(settings, "name"));
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-						     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+				reportFailure("MainOutputNotActive");
 				return false;
 			}
 			auto vei = (int)obs_data_get_int(settings, "video_encoder_index");
@@ -908,8 +1053,7 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				blog(LOG_WARNING,
 				     "[Aitum Multistream] failed to start stream '%s' because encoder index %d was not found",
 				     obs_data_get_string(settings, "name"), vei);
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
-						     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
+				reportFailure("MainOutputEncoderIndexNotFound");
 				return false;
 			}
 		} else {
@@ -944,8 +1088,7 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				obs_output_release(main_output);
 				blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 				     obs_data_get_string(settings, "name"));
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-						     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+				reportFailure("MainOutputNotActive");
 				return false;
 			}
 			auto aei = (int)obs_data_get_int(settings, "audio_encoder_index");
@@ -955,8 +1098,7 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 				blog(LOG_WARNING,
 				     "[Aitum Multistream] failed to start stream '%s' because encoder index %d was not found",
 				     obs_data_get_string(settings, "name"), aei);
-				QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")),
-						     QString::fromUtf8(obs_module_text("MainOutputEncoderIndexNotFound")));
+				reportFailure("MainOutputEncoderIndexNotFound");
 				return false;
 			}
 		} else {
@@ -981,8 +1123,7 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 			obs_output_release(main_output);
 			blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s' because main was not started",
 			     obs_data_get_string(settings, "name"));
-			QMessageBox::warning(this, QString::fromUtf8(obs_module_text("MainOutputNotActive")),
-					     QString::fromUtf8(obs_module_text("MainOutputNotActive")));
+			reportFailure("MainOutputNotActive");
 			return false;
 		}
 
@@ -1062,9 +1203,29 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 	obs_output_set_video_encoder(output, venc);
 	obs_output_set_audio_encoder(output, aenc, 0);
 
-	obs_output_start(output);
-
 	outputs.push_back({obs_data_get_string(settings, "name"), output, streamButton});
+
+	if (!obs_output_start(output)) {
+		// A start that fails here never raises "stop", so nothing else will
+		// clean up after it. Left in the list the name would look permanently
+		// busy, and an output configured to start with the main output would
+		// never be started again.
+		auto last_error = obs_output_get_last_error(output);
+		blog(LOG_WARNING, "[Aitum Multistream] failed to start stream '%s'%s%s", name, last_error ? ": " : "",
+		     last_error ? last_error : "");
+		for (auto it = outputs.begin(); it != outputs.end(); it++) {
+			if (std::get<obs_output_t *>(*it) != output)
+				continue;
+			outputs.erase(it);
+			break;
+		}
+		signal_handler_disconnect(signal, "start", stream_output_start, this);
+		signal_handler_disconnect(signal, "stop", stream_output_stop, this);
+		auto failed_service = obs_output_get_service(output);
+		obs_output_release(output);
+		obs_service_release(failed_service);
+		return false;
+	}
 
 	return true;
 }
@@ -1072,46 +1233,71 @@ bool MultistreamDock::StartOutput(obs_data_t *settings, QPushButton *streamButto
 void MultistreamDock::stream_output_start(void *data, calldata_t *calldata)
 {
 	auto md = (MultistreamDock *)data;
-	auto output = (obs_output_t *)calldata_ptr(calldata, "output");
-	for (auto it = md->outputs.begin(); it != md->outputs.end(); it++) {
-		if (std::get<obs_output_t *>(*it) != output)
-			continue;
-		auto button = std::get<QPushButton *>(*it);
-		if (!button->isChecked()) {
-			QMetaObject::invokeMethod(
-				button,
-				[button, md] {
+	auto output = obs_output_get_ref((obs_output_t *)calldata_ptr(calldata, "output"));
+	if (!output)
+		return;
+	// Raised on the output's own thread. Everything below belongs to the UI
+	// thread -- the outputs list, the buttons, pending_auto_stop -- so hand the
+	// whole job over rather than doing any of it here. The reference keeps the
+	// output alive for the trip.
+	QMetaObject::invokeMethod(
+		md,
+		[md, output] {
+			for (auto it = md->outputs.begin(); it != md->outputs.end(); it++) {
+				if (std::get<obs_output_t *>(*it) != output)
+					continue;
+				auto button = std::get<QPushButton *>(*it);
+				if (button && !button->isChecked()) {
 					button->setChecked(true);
 					md->outputButtonStyle(button);
-				},
-				Qt::QueuedConnection);
-		}
-	}
+				}
+				// If the main output went down while this one was still
+				// connecting, the stop asked for then did nothing, because
+				// obs_output_stop() ignores an output that is neither active
+				// nor reconnecting. It has started now, so it can be stopped.
+				auto name = std::get<std::string>(*it);
+				if (md->pending_auto_stop.erase(name)) {
+					blog(LOG_INFO,
+					     "[Aitum Multistream] stopping '%s' now it has connected, main already stopped",
+					     name.c_str());
+					StopOutput(output);
+				}
+				break;
+			}
+			obs_output_release(output);
+		},
+		Qt::QueuedConnection);
 }
 
 void MultistreamDock::stream_output_stop(void *data, calldata_t *calldata)
 {
 	auto md = (MultistreamDock *)data;
-	auto output = (obs_output_t *)calldata_ptr(calldata, "output");
-	for (auto it = md->outputs.begin(); it != md->outputs.end(); it++) {
-		if (std::get<obs_output_t *>(*it) != output)
-			continue;
-		auto button = std::get<QPushButton *>(*it);
-		if (button->isChecked()) {
-			QMetaObject::invokeMethod(
-				button,
-				[button, md] {
+	auto output = obs_output_get_ref((obs_output_t *)calldata_ptr(calldata, "output"));
+	if (!output)
+		return;
+	// Same as above: raised on the output's thread, all of the work is the UI
+	// thread's. Doing the release and the erase here is what used to collide
+	// with StartOutput tearing the same entry down.
+	QMetaObject::invokeMethod(
+		md,
+		[md, output] {
+			for (auto it = md->outputs.begin(); it != md->outputs.end(); it++) {
+				if (std::get<obs_output_t *>(*it) != output)
+					continue;
+				auto button = std::get<QPushButton *>(*it);
+				if (button && button->isChecked()) {
 					button->setChecked(false);
 					md->outputButtonStyle(button);
-				},
-				Qt::QueuedConnection);
-		}
-		if (!md->exiting)
-			QMetaObject::invokeMethod(button, [output] { obs_output_release(output); }, Qt::QueuedConnection);
-		md->outputs.erase(it);
-		break;
-	}
-	//const char *last_error = (const char *)calldata_ptr(calldata, "last_error");
+				}
+				md->pending_auto_stop.erase(std::get<std::string>(*it));
+				if (!md->exiting)
+					obs_output_release(output);
+				md->outputs.erase(it);
+				break;
+			}
+			obs_output_release(output);
+		},
+		Qt::QueuedConnection);
 }
 
 void MultistreamDock::ApiInfo(QString info)

--- a/multistream.hpp
+++ b/multistream.hpp
@@ -8,6 +8,7 @@
 #include <QString>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <set>
 
 class OBSBasicSettings;
 
@@ -46,7 +47,23 @@ private:
 	void LoadOutput(obs_data_t *data, bool vertical);
 	void SaveSettings();
 
-	bool StartOutput(obs_data_t *settings, QPushButton *streamButton);
+	// `automatic` marks a start the user did not ask for directly -- one
+	// triggered by the main output starting. Those never open a dialog: there
+	// may be nobody at the machine, and one modal per output would wedge OBS.
+	// A true return means the start was accepted, NOT that the output is live;
+	// only the output's own "start" signal means that.
+	bool StartOutput(obs_data_t *settings, QPushButton *streamButton, bool automatic = false);
+
+	// Follow-the-main-output automation. Both run on the Qt UI thread from
+	// frontend_event.
+	void StartOutputsWithMain();
+	void StopOutputsWithMain();
+
+	// Outputs asked to stop while they were still connecting. obs_output_stop()
+	// does nothing for an output that is neither active nor reconnecting, so the
+	// request is remembered by name here and re-issued once the output reports
+	// that it started. Touched on the UI thread only.
+	std::set<std::string> pending_auto_stop;
 
 	void outputButtonStyle(QPushButton *button);
 


### PR DESCRIPTION
> **Credit:** the feature is [@xcopy94](https://github.com/xcopy94)'s idea and design from #17. This is a fresh implementation against current `main` rather than a rebase — #17 conflicts with `fc493a3` and the conflict cannot be resolved textually without changing behaviour. If the original author would rather take these changes into #17, please close this; it is offered as a ready-to-merge alternative, not a replacement for their work.

## What this does

Two per-output settings, **"Start with main output"** and **"Stop with main output"**. With them ticked, starting or stopping the main OBS stream also starts or stops that output.

The point is remote control. Stream decks, obs-websocket clients and phone dashboards mostly only know `StartStream` / `StopStream`, which act on the main output alone — so a multistream setup could not be driven from anywhere but the machine itself.

## Addressing the review on #17

**@hnicke — the confirmation dialog appeared on remote starts.** Fixed, and more thoroughly than #17: that PR suppresses the confirm-before-starting question, but leaves the five `QMessageBox::warning` failure dialogs. With several misconfigured outputs those stack one modal per output and wedge OBS with nobody there to dismiss them. All six now go through a single `reportFailure` helper that shows nothing on an automatic start. The log line is written either way, since on an unattended machine the log is the only feedback there is.

**@exeldro — "obs_output_start is not always blocking until the output starts or fails to."** This is the concern that shaped the design. Nothing here infers "the output is live" from a return value:

- Outputs are started and then left alone; their own `start`/`stop` signals drive all state.
- An output already running *or still connecting* is skipped rather than restarted, so starting the main stream cannot kill something the user had going. `obs_output_active()` is not used for that test — it is false for the whole RTMP connect phase.
- `obs_output_start()`'s `bool` return **is** checked (it was being discarded). A synchronous failure raises no `stop` signal, so nothing would ever clean up after it; the entry is unwound inline and the reason logged via `obs_output_get_last_error()`.
- Conversely, `obs_output_stop()` returns without doing anything if the output is neither active nor reconnecting — again the whole connect phase. So "start the main stream, stop it two seconds later" would silently fail to stop the followers and they would go live afterwards, orphaned. Those names are remembered and stopped as soon as they report that they started. This is tested below.

**@xcopy94 — encoder load when many outputs start at once.** Not addressed by staggering, deliberately: outputs that borrow the main encoders share them by reference, so N followers do not mean N encode sessions. An output with its own encoder is the user's explicit choice, as it already is today when starting by hand. Flagged as a known limitation rather than claimed solved.

**The PR conflicts with main.** Rewritten against current `main` instead of rebased — see below.

## What is deliberately different from #17

**The checkboxes are not in the Advanced Settings tabs.** #17 adds an "Automation Settings" tab inside `advancedTabWidget`. Since `fc493a3` that widget is only shown when `advanced` is ticked, and `advanced` now means *"give this output its own encoder"* — so reaching an automation checkbox would require changing how the output encodes. They sit in the expanded section next to the Advanced Settings checkbox instead, and only for main-canvas outputs.

**The `advanced` branch in `StartOutput` is untouched.** #17's commit `4ebe3c9` comments out `auto advanced = obs_data_get_bool(settings, "advanced");` and makes every output take the advanced path. That silently undoes `fc493a3`, gives non-advanced outputs their own encode session built from stale `video_encoder` / `scale` / frame-rate-divisor settings, and ships with no migration. It is also why the PR conflicts.

**No Qt signals.** #17 emits `requestingStart(bool pending)` / `requestingStop(bool pending)` for both the STARTING and STARTED events and filters on an inverted `pend` flag, keeping the connections in an `ss_connections` vector whose lambdas capture an `obs_data_t *` and a `QPushButton *` — both of which are replaced on a settings change and deleted on every `LoadSettings`. The events are just tested directly in `frontend_event`.

**Which events, and why:**

| | event | why not the other one |
|---|---|---|
| start | `STREAMING_STARTED` | at `STARTING` the main output is not active yet, so every output borrowing a main encoder is refused; `STARTING` is also emitted for main starts that then fail with no compensating event |
| stop | `STREAMING_STOPPING` **and** `STOPPED` | libobs only raises `"stopping"` from `obs_output_stop`/`force_stop`, so a main stream that drops on its own produces `STOPPED` with no `STOPPING` — the followers would keep streaming after the main one died. Running twice is harmless: anything stopped at `STOPPING` has already left the list |

**The double-free is fixed structurally.** #17 disconnects the `stop` handler before `obs_output_force_stop` — but only inside `if (obs_output_active(old))`, which is false for the entire connect phase, so it misses the window it is meant to cover, and it cannot stop a callback already running on another thread. Here the handlers are disconnected unconditionally, the entry is erased before anything that can re-enter, and — the part that actually makes it hold — both signal handlers stop doing work on the output's signal thread and hand the job to the UI thread. That also removes two existing `QPushButton` calls that were being made off the GUI thread.

## The commits

1. **`fix: free a replaced output exactly once`** — a standalone bug fix against `main`, mergeable on its own and useful without the feature.
2. **`feat: start and stop outputs with the main output`** — the settings, the UI and the follow logic.

## How this was tested

Built and run for real: **OBS Studio 32.2.1, Qt 6.11.1**, plugin built out of tree, streaming to local `ffmpeg -listen` RTMP sinks so nothing leaves the machine. Driven over obs-websocket so the "remote control" path is the one actually exercised, with **`WarnBeforeStartingStream` enabled throughout** — a stray modal would block OBS's UI thread and every request would time out.

**Start/stop following — 5/5**

```
[PASS] StartStream started both follow-along outputs      {"LocalTwitch": true, "LocalYouTube": true}
[PASS] StopStream stopped both follow-along outputs       {}
[PASS] a stop issued during the connect phase is not lost {}
[PASS] main stream is stopped at the end
```

**Per-output flags and the skip path — 4/4**

```
[PASS] both outputs started with the main output              {"LocalTwitch": true, "LocalYouTube": true}
[PASS] only the output set to stop with main stopped          {"LocalTwitch": true}
[PASS] restarting main left the still-running output alone    {"LocalYouTube": true, "LocalTwitch": true}
[PASS] OBS never blocked on a confirmation dialog
```

with the log confirming the output already running was skipped rather than restarted — the exact case that triggers the double free:

```
[Aitum Multistream] 'LocalTwitch' is already running, not starting it with the main output
```

**The deferred stop.** To make this deterministic rather than accidental, one output was put behind a proxy that stalls the RTMP handshake for five seconds, so the stop lands while it is provably still connecting:

```
02:55:57.175  starting stream 'LocalYouTube' with the main output
02:55:57.175  starting stream 'LocalTwitch' with the main output
02:55:58.532  'LocalYouTube' is still connecting, it will be stopped as soon as it starts
02:55:58.532  stopping stream 'LocalTwitch' with the main output          <- normal path
02:56:02.362  stopping 'LocalYouTube' now it has connected, main already stopped   <- deferred path
```

Final state: nothing left running. Both paths exercised in one run.

## Notes for reviewers

- **Not tested:** Windows and macOS, WHIP/SRT outputs (RTMP only), and OBS's stream delay. With delay enabled `STREAMING_STARTED` is deferred by the whole delay, so followers start late while the stop is still immediate.
- **Vertical outputs are out of scope.** They are driven through the `aitum_vertical_*` proc handlers rather than `StartOutput`, and their settings object is handed back to that plugin, so writing these keys into it would persist settings nothing reads. The checkboxes are gated on the existing `main` flag.
- **A profile change mid-stream is not handled.** `PROFILE_CHANGING` is the only hook that precedes OBS replacing the main encoders; an output still running across it is a pre-existing problem this PR does not make worse or better.
- **`stop_w_main` stops outputs the user started by hand**, if that output has the flag set. That seemed the least surprising reading of the setting, but say if you would rather it only stopped what it started.
- On a normal user-initiated stop both `STOPPING` and `STOPPED` arrive, so the stop pass runs twice and you will see two log lines per output. The second is a no-op.
- **Pre-existing and left alone:** the encoders and service created per start are never released on `main` either. Real leaks, but out of scope here.
